### PR TITLE
More dep fixes

### DIFF
--- a/aws-common/pom.xml
+++ b/aws-common/pom.xml
@@ -39,6 +39,19 @@
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
         </dependency>
+        <!--
+        There's a bug in
+        https://github.com/apache/httpclient/blob/4.5.2/httpclient/src/main/java-deprecated/org/apache/http/impl/client/AbstractHttpClient.java#L332
+        Where httpclient does not care what your context classloader is when looking for
+        A few extensions depend on jets3t, so we include it explicitly here to make sure it can load up its
+        org.jets3t.service.utils.RestUtils$ConnManagerFactory
+        properly
+        -->
+        <dependency>
+            <groupId>net.java.dev.jets3t</groupId>
+            <artifactId>jets3t</artifactId>
+            <version>0.9.4</version>
+        </dependency>
 
         <!-- Tests -->
         <dependency>

--- a/docs/content/development/modules.md
+++ b/docs/content/development/modules.md
@@ -187,3 +187,40 @@ If you want your extension to be included, you can add your extension's maven co
 
 During `mvn install`, maven will install your extension to the local maven repository, and then call [pull-deps](../operations/pull-deps.html) to pull your extension from
 there. In the end, you should see your extension underneath `distribution/target/extensions` and within Druid tarball.
+
+### Managing dependencies
+Managing library collisions can be daunting for extensions which draw in commonly used libraries. Here is a list of group IDs for libraries that are suggested to be specified with a `provided` scope to prevent collision with versions used in druid:
+```
+"io.druid",
+"com.metamx.druid",
+"asm",
+"org.ow2.asm",
+"org.jboss.netty",
+"com.google.guava",
+"com.google.code.findbugs",
+"com.google.protobuf",
+"com.esotericsoftware.minlog",
+"log4j",
+"org.slf4j",
+"commons-logging",
+"org.eclipse.jetty",
+"org.mortbay.jetty",
+"com.sun.jersey",
+"com.sun.jersey.contribs",
+"common-beanutils",
+"commons-codec",
+"commons-lang",
+"commons-cli",
+"commons-io",
+"javax.activation",
+"org.apache.httpcomponents",
+"org.apache.zookeeper",
+"org.codehaus.jackson",
+"com.fasterxml.jackson",
+"com.fasterxml.jackson.core",
+"com.fasterxml.jackson.dataformat",
+"com.fasterxml.jackson.datatype",
+"org.roaringbitmap",
+"net.java.dev.jets3t"
+```
+See the documentation in `io.druid.cli.PullDependencies` for more information.

--- a/extensions/azure-extensions/pom.xml
+++ b/extensions/azure-extensions/pom.xml
@@ -34,12 +34,27 @@
         <dependency>
             <groupId>io.druid</groupId>
             <artifactId>druid-api</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-storage</artifactId>
             <version>2.1.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Tests -->

--- a/extensions/cassandra-storage/pom.xml
+++ b/extensions/cassandra-storage/pom.xml
@@ -34,15 +34,88 @@
         <dependency>
             <groupId>io.druid</groupId>
             <artifactId>druid-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.netflix.astyanax</groupId>
             <artifactId>astyanax</artifactId>
             <version>1.0.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>jline</groupId>
+                    <artifactId>jline</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>joda-time</groupId>
+                    <artifactId>joda-time</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.mortbay.jetty</groupId>
+                    <artifactId>jetty-util</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.ning</groupId>
+                    <artifactId>compress-lzf</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                </exclusion>
+                <!-- Coppied from hadoop exclusions -->
+                <exclusion>
+                    <groupId>commons-cli</groupId>
+                    <artifactId>commons-cli</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-httpclient</groupId>
+                    <artifactId>commons-httpclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+                    <artifactId>commons-codec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpcore</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-core-asl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-mapper-asl</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Tests -->

--- a/extensions/cloudfiles-extensions/pom.xml
+++ b/extensions/cloudfiles-extensions/pom.xml
@@ -45,11 +45,18 @@
         <dependency>
             <groupId>io.druid</groupId>
             <artifactId>druid-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
             <version>${guice.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>aopalliance</groupId>
+                    <artifactId>aopalliance</artifactId>
+                </exclusion>
+            </exclusions>
             <!--$NO-MVN-MAN-VER$ -->
         </dependency>
         <dependency>
@@ -69,11 +76,27 @@
             <groupId>org.apache.jclouds.driver</groupId>
             <artifactId>jclouds-slf4j</artifactId>
             <version>${jclouds.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>jsr311-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.jclouds.driver</groupId>
             <artifactId>jclouds-sshj</artifactId>
             <version>${jclouds.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- Rackspace US dependencies -->
         <dependency>

--- a/extensions/hdfs-storage/pom.xml
+++ b/extensions/hdfs-storage/pom.xml
@@ -43,27 +43,96 @@
             <version>${project.parent.version}</version>
             <scope>provided</scope>
         </dependency>
-        <!-- override jets3t from hadoop-core -->
-        <dependency>
-            <groupId>net.java.dev.jets3t</groupId>
-            <artifactId>jets3t</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <!-- override httpclient / httpcore version from jets3t -->
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
-            <scope>provided</scope>
-        </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
             <scope>compile</scope>
+            <exclusions>
+              <exclusion>
+                <groupId>commons-cli</groupId>
+                <artifactId>commons-cli</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>commons-httpclient</groupId>
+                <artifactId>commons-httpclient</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>commons-logging</groupId>
+                <artifactId>commons-logging</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>commons-lang</groupId>
+                <artifactId>commons-lang</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpcore</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-core-asl</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.codehaus.jackson</groupId>
+                <artifactId>jackson-mapper-asl</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-log4j12</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>javax.ws.rs</groupId>
+                <artifactId>jsr311-api</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.mortbay.jetty</groupId>
+                <artifactId>jetty-util</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-annotations</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>javax.activation</groupId>
+                <artifactId>activation</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>com.sun.jersey</groupId>
+                <artifactId>jersey-core</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.metamx</groupId>

--- a/extensions/histogram/pom.xml
+++ b/extensions/histogram/pom.xml
@@ -35,6 +35,7 @@
             <groupId>io.druid</groupId>
             <artifactId>druid-processing</artifactId>
             <version>${project.parent.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Tests -->

--- a/extensions/kafka-eight-simpleConsumer/pom.xml
+++ b/extensions/kafka-eight-simpleConsumer/pom.xml
@@ -34,10 +34,12 @@
     <dependency>
       <groupId>io.druid</groupId>
       <artifactId>druid-api</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.metamx</groupId>
       <artifactId>emitter</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>
@@ -51,6 +53,14 @@
         <exclusion>
           <groupId>org.apache.zookeeper</groupId>
           <artifactId>zookeeper</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>net.jpountz.lz4</groupId>
+          <artifactId>lz4</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/extensions/kafka-eight/pom.xml
+++ b/extensions/kafka-eight/pom.xml
@@ -35,11 +35,30 @@
         <dependency>
             <groupId>io.druid</groupId>
             <artifactId>druid-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.10</artifactId>
             <version>0.8.2.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>net.jpountz.lz4</groupId>
+                    <artifactId>lz4</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Tests -->

--- a/extensions/kafka-extraction-namespace/pom.xml
+++ b/extensions/kafka-extraction-namespace/pom.xml
@@ -36,11 +36,13 @@
     <dependency>
       <groupId>io.druid</groupId>
       <artifactId>druid-api</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.druid</groupId>
       <artifactId>druid-processing</artifactId>
       <version>${project.parent.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.druid.extensions</groupId>
@@ -51,6 +53,7 @@
       <groupId>io.druid</groupId>
       <artifactId>druid-server</artifactId>
       <version>${project.parent.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>
@@ -64,6 +67,14 @@
         <exclusion>
           <groupId>org.apache.zookeeper</groupId>
           <artifactId>zookeeper</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>net.jpountz.lz4</groupId>
+          <artifactId>lz4</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/extensions/namespace-lookup/pom.xml
+++ b/extensions/namespace-lookup/pom.xml
@@ -36,16 +36,19 @@
     <dependency>
       <groupId>io.druid</groupId>
       <artifactId>druid-api</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.druid</groupId>
       <artifactId>druid-processing</artifactId>
       <version>${project.parent.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.druid</groupId>
       <artifactId>druid-server</artifactId>
       <version>${project.parent.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <!-- Tests -->

--- a/extensions/rabbitmq/pom.xml
+++ b/extensions/rabbitmq/pom.xml
@@ -35,6 +35,7 @@
         <dependency>
             <groupId>io.druid</groupId>
             <artifactId>druid-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.rabbitmq</groupId>
@@ -45,6 +46,12 @@
             <groupId>net.jodah</groupId>
             <artifactId>lyra</artifactId>
             <version>0.3.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Tests -->

--- a/extensions/s3-extensions/pom.xml
+++ b/extensions/s3-extensions/pom.xml
@@ -44,27 +44,9 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- override jets3t from hadoop-core -->
         <dependency>
             <groupId>net.java.dev.jets3t</groupId>
             <artifactId>jets3t</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <!-- jets3t requires log4j 1.2 compatability -->
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-1.2-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <!-- override httpclient / httpcore version from jets3t -->
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/indexing-hadoop/pom.xml
+++ b/indexing-hadoop/pom.xml
@@ -53,19 +53,23 @@
         <dependency>
             <groupId>net.java.dev.jets3t</groupId>
             <artifactId>jets3t</artifactId>
+	    <scope>test</scope>
         </dependency>
         <!-- override httpclient / httpcore version from jets3t -->
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,12 @@
                 <groupId>com.metamx</groupId>
                 <artifactId>java-util</artifactId>
                 <version>${metamx.java-util.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.metamx</groupId>
@@ -201,6 +207,12 @@
                 <groupId>org.skife.config</groupId>
                 <artifactId>config-magic</artifactId>
                 <version>0.9</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.curator</groupId>
@@ -466,6 +478,12 @@
                 <groupId>io.tesla.aether</groupId>
                 <artifactId>tesla-aether</artifactId>
                 <version>0.0.5</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.aether</groupId>
@@ -476,6 +494,32 @@
                 <groupId>net.java.dev.jets3t</groupId>
                 <artifactId>jets3t</artifactId>
                 <version>0.9.4</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-codec</groupId>
+                        <artifactId>commons-codec</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.httpcomponents</groupId>
+                        <artifactId>httpclient</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.httpcomponents</groupId>
+                        <artifactId>httpcore</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.codehaus.jackson</groupId>
+                        <artifactId>jackson-core-asl</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.codehaus.jackson</groupId>
+                        <artifactId>jackson-mapper-asl</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <!-- The htttpcomponents artifacts have non-matching release cadence -->
             <dependency>
@@ -558,6 +602,12 @@
                 <groupId>com.ircclouds.irc</groupId>
                 <artifactId>irc-api</artifactId>
                 <version>1.0-0014</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>com.maxmind.geoip2</groupId>

--- a/services/src/main/java/io/druid/cli/PullDependencies.java
+++ b/services/src/main/java/io/druid/cli/PullDependencies.java
@@ -64,8 +64,7 @@ public class PullDependencies implements Runnable
   private static final Logger log = new Logger(PullDependencies.class);
 
   private static final Set<String> exclusions = Sets.newHashSet(
-      "io.druid",
-      "com.metamx.druid",
+      /*
 
       // It is possible that extensions will pull down a lot of jars that are either
       // duplicates OR conflict with druid jars. In that case, there are two problems that arise
@@ -94,6 +93,14 @@ public class PullDependencies implements Runnable
       // Different tasks which are classloader sensitive attempt to maintain a sane order for loading libraries in the
       // classloader, but it is always possible that something didn't load in the right order. Also we don't want to be
       // throwing around a ton of jars we don't need to.
+      //
+      // Here is a list of dependencies extensions should probably exclude.
+      //
+      // Conflicts can be discovered using the following command on the distribution tarball:
+      //    `find lib -iname *.jar | cut -d / -f 2 | sed -e 's/-[0-9]\.[0-9]/@/' | cut -f 1 -d @ | sort | uniq | xargs -I {} find extensions -name "*{}*.jar" | sort`
+
+      "io.druid",
+      "com.metamx.druid",
       "asm",
       "org.ow2.asm",
       "org.jboss.netty",
@@ -123,6 +130,7 @@ public class PullDependencies implements Runnable
       "com.fasterxml.jackson.datatype",
       "org.roaringbitmap",
       "net.java.dev.jets3t"
+      */
   );
 
   private TeslaAether aether;
@@ -294,6 +302,19 @@ public class PullDependencies implements Runnable
               @Override
               public boolean accept(DependencyNode node, List<DependencyNode> parents)
               {
+                String scope = node.getDependency().getScope();
+                if(scope != null) {
+                  scope = scope.toLowerCase();
+                  if(scope.equals("provided")) {
+                    return false;
+                  }
+                  if(scope.equals("test")) {
+                    return false;
+                  }
+                  if(scope.equals("system")) {
+                    return false;
+                  }
+                }
                 if (accept(node.getArtifact())) {
                   return false;
                 }


### PR DESCRIPTION
At this point, here's the output of collision libraries:

```
druid-0.9.0-rc3-SNAPSHOT charlesallen$ find lib -iname *.jar | cut -d / -f 2 | sed -e 's/-[0-9]\.[0-9]/@/' | cut -f 1 -d @ | sort | uniq | xargs -I {} find extensions -name "*{}*.jar" | sort
extensions/druid-cloudfiles-extensions/guice-3.0.jar
extensions/druid-cloudfiles-extensions/guice-assistedinject-3.0.jar
extensions/druid-cloudfiles-extensions/guice-multibindings-3.0.jar
extensions/druid-cloudfiles-extensions/guice-multibindings-3.0.jar
extensions/druid-cloudfiles-extensions/guice-servlet-3.0.jar
extensions/druid-cloudfiles-extensions/guice-servlet-3.0.jar
extensions/druid-examples/RoaringBitmap-0.5.16.jar
extensions/druid-examples/activation-1.1.1.jar
extensions/druid-examples/aether-api-0.9.0.M2.jar
extensions/druid-examples/aether-connector-file-0.9.0.M2.jar
extensions/druid-examples/aether-connector-okhttp-0.0.9.jar
extensions/druid-examples/aether-connector-okhttp-0.0.9.jar
extensions/druid-examples/aether-impl-0.9.0.M2.jar
extensions/druid-examples/aether-spi-0.9.0.M2.jar
extensions/druid-examples/aether-util-0.9.0.M2.jar
extensions/druid-examples/airline-0.7.jar
extensions/druid-examples/annotations-2.0.3.jar
extensions/druid-examples/antlr4-runtime-4.0.jar
extensions/druid-examples/aopalliance-1.0.jar
extensions/druid-examples/aws-java-sdk-1.10.21.jar
extensions/druid-examples/aws-java-sdk-autoscaling-1.10.21.jar
extensions/druid-examples/aws-java-sdk-autoscaling-1.10.21.jar
extensions/druid-examples/aws-java-sdk-cloudformation-1.10.21.jar
extensions/druid-examples/aws-java-sdk-cloudformation-1.10.21.jar
extensions/druid-examples/aws-java-sdk-cloudfront-1.10.21.jar
extensions/druid-examples/aws-java-sdk-cloudfront-1.10.21.jar
extensions/druid-examples/aws-java-sdk-cloudhsm-1.10.21.jar
extensions/druid-examples/aws-java-sdk-cloudhsm-1.10.21.jar
extensions/druid-examples/aws-java-sdk-cloudsearch-1.10.21.jar
extensions/druid-examples/aws-java-sdk-cloudsearch-1.10.21.jar
extensions/druid-examples/aws-java-sdk-cloudtrail-1.10.21.jar
extensions/druid-examples/aws-java-sdk-cloudtrail-1.10.21.jar
extensions/druid-examples/aws-java-sdk-cloudwatch-1.10.21.jar
extensions/druid-examples/aws-java-sdk-cloudwatch-1.10.21.jar
extensions/druid-examples/aws-java-sdk-cloudwatchmetrics-1.10.21.jar
extensions/druid-examples/aws-java-sdk-cloudwatchmetrics-1.10.21.jar
extensions/druid-examples/aws-java-sdk-cloudwatchmetrics-1.10.21.jar
extensions/druid-examples/aws-java-sdk-codecommit-1.10.21.jar
extensions/druid-examples/aws-java-sdk-codecommit-1.10.21.jar
extensions/druid-examples/aws-java-sdk-codedeploy-1.10.21.jar
extensions/druid-examples/aws-java-sdk-codedeploy-1.10.21.jar
extensions/druid-examples/aws-java-sdk-codepipeline-1.10.21.jar
extensions/druid-examples/aws-java-sdk-codepipeline-1.10.21.jar
extensions/druid-examples/aws-java-sdk-cognitoidentity-1.10.21.jar
extensions/druid-examples/aws-java-sdk-cognitoidentity-1.10.21.jar
extensions/druid-examples/aws-java-sdk-cognitosync-1.10.21.jar
extensions/druid-examples/aws-java-sdk-cognitosync-1.10.21.jar
extensions/druid-examples/aws-java-sdk-config-1.10.21.jar
extensions/druid-examples/aws-java-sdk-config-1.10.21.jar
extensions/druid-examples/aws-java-sdk-core-1.10.21.jar
extensions/druid-examples/aws-java-sdk-core-1.10.21.jar
extensions/druid-examples/aws-java-sdk-datapipeline-1.10.21.jar
extensions/druid-examples/aws-java-sdk-datapipeline-1.10.21.jar
extensions/druid-examples/aws-java-sdk-devicefarm-1.10.21.jar
extensions/druid-examples/aws-java-sdk-devicefarm-1.10.21.jar
extensions/druid-examples/aws-java-sdk-directconnect-1.10.21.jar
extensions/druid-examples/aws-java-sdk-directconnect-1.10.21.jar
extensions/druid-examples/aws-java-sdk-directory-1.10.21.jar
extensions/druid-examples/aws-java-sdk-directory-1.10.21.jar
extensions/druid-examples/aws-java-sdk-dynamodb-1.10.21.jar
extensions/druid-examples/aws-java-sdk-dynamodb-1.10.21.jar
extensions/druid-examples/aws-java-sdk-ec2-1.10.21.jar
extensions/druid-examples/aws-java-sdk-ec2-1.10.21.jar
extensions/druid-examples/aws-java-sdk-ecs-1.10.21.jar
extensions/druid-examples/aws-java-sdk-ecs-1.10.21.jar
extensions/druid-examples/aws-java-sdk-efs-1.10.21.jar
extensions/druid-examples/aws-java-sdk-efs-1.10.21.jar
extensions/druid-examples/aws-java-sdk-elasticache-1.10.21.jar
extensions/druid-examples/aws-java-sdk-elasticache-1.10.21.jar
extensions/druid-examples/aws-java-sdk-elasticbeanstalk-1.10.21.jar
extensions/druid-examples/aws-java-sdk-elasticbeanstalk-1.10.21.jar
extensions/druid-examples/aws-java-sdk-elasticloadbalancing-1.10.21.jar
extensions/druid-examples/aws-java-sdk-elasticloadbalancing-1.10.21.jar
extensions/druid-examples/aws-java-sdk-elastictranscoder-1.10.21.jar
extensions/druid-examples/aws-java-sdk-elastictranscoder-1.10.21.jar
extensions/druid-examples/aws-java-sdk-emr-1.10.21.jar
extensions/druid-examples/aws-java-sdk-emr-1.10.21.jar
extensions/druid-examples/aws-java-sdk-glacier-1.10.21.jar
extensions/druid-examples/aws-java-sdk-glacier-1.10.21.jar
extensions/druid-examples/aws-java-sdk-iam-1.10.21.jar
extensions/druid-examples/aws-java-sdk-iam-1.10.21.jar
extensions/druid-examples/aws-java-sdk-importexport-1.10.21.jar
extensions/druid-examples/aws-java-sdk-importexport-1.10.21.jar
extensions/druid-examples/aws-java-sdk-kinesis-1.10.21.jar
extensions/druid-examples/aws-java-sdk-kinesis-1.10.21.jar
extensions/druid-examples/aws-java-sdk-kms-1.10.21.jar
extensions/druid-examples/aws-java-sdk-kms-1.10.21.jar
extensions/druid-examples/aws-java-sdk-lambda-1.10.21.jar
extensions/druid-examples/aws-java-sdk-lambda-1.10.21.jar
extensions/druid-examples/aws-java-sdk-logs-1.10.21.jar
extensions/druid-examples/aws-java-sdk-logs-1.10.21.jar
extensions/druid-examples/aws-java-sdk-machinelearning-1.10.21.jar
extensions/druid-examples/aws-java-sdk-machinelearning-1.10.21.jar
extensions/druid-examples/aws-java-sdk-opsworks-1.10.21.jar
extensions/druid-examples/aws-java-sdk-opsworks-1.10.21.jar
extensions/druid-examples/aws-java-sdk-rds-1.10.21.jar
extensions/druid-examples/aws-java-sdk-rds-1.10.21.jar
extensions/druid-examples/aws-java-sdk-redshift-1.10.21.jar
extensions/druid-examples/aws-java-sdk-redshift-1.10.21.jar
extensions/druid-examples/aws-java-sdk-route53-1.10.21.jar
extensions/druid-examples/aws-java-sdk-route53-1.10.21.jar
extensions/druid-examples/aws-java-sdk-s3-1.10.21.jar
extensions/druid-examples/aws-java-sdk-s3-1.10.21.jar
extensions/druid-examples/aws-java-sdk-ses-1.10.21.jar
extensions/druid-examples/aws-java-sdk-ses-1.10.21.jar
extensions/druid-examples/aws-java-sdk-simpledb-1.10.21.jar
extensions/druid-examples/aws-java-sdk-simpledb-1.10.21.jar
extensions/druid-examples/aws-java-sdk-simpleworkflow-1.10.21.jar
extensions/druid-examples/aws-java-sdk-simpleworkflow-1.10.21.jar
extensions/druid-examples/aws-java-sdk-sns-1.10.21.jar
extensions/druid-examples/aws-java-sdk-sns-1.10.21.jar
extensions/druid-examples/aws-java-sdk-sqs-1.10.21.jar
extensions/druid-examples/aws-java-sdk-sqs-1.10.21.jar
extensions/druid-examples/aws-java-sdk-ssm-1.10.21.jar
extensions/druid-examples/aws-java-sdk-ssm-1.10.21.jar
extensions/druid-examples/aws-java-sdk-storagegateway-1.10.21.jar
extensions/druid-examples/aws-java-sdk-storagegateway-1.10.21.jar
extensions/druid-examples/aws-java-sdk-sts-1.10.21.jar
extensions/druid-examples/aws-java-sdk-sts-1.10.21.jar
extensions/druid-examples/aws-java-sdk-support-1.10.21.jar
extensions/druid-examples/aws-java-sdk-support-1.10.21.jar
extensions/druid-examples/aws-java-sdk-swf-libraries-1.10.21.jar
extensions/druid-examples/aws-java-sdk-swf-libraries-1.10.21.jar
extensions/druid-examples/aws-java-sdk-workspaces-1.10.21.jar
extensions/druid-examples/aws-java-sdk-workspaces-1.10.21.jar
extensions/druid-examples/base64-2.3.8.jar
extensions/druid-examples/bcprov-jdk15on-1.52.jar
extensions/druid-examples/bytebuffer-collections-0.2.4.jar
extensions/druid-examples/classmate-1.0.0.jar
extensions/druid-examples/commons-cli-1.2.jar
extensions/druid-examples/commons-codec-1.7.jar
extensions/druid-examples/commons-dbcp2-2.0.1.jar
extensions/druid-examples/commons-io-2.4.jar
extensions/druid-examples/commons-lang-2.6.jar
extensions/druid-examples/commons-logging-1.1.1.jar
extensions/druid-examples/commons-pool-1.6.jar
extensions/druid-examples/commons-pool2-2.2.jar
extensions/druid-examples/commons-pool2-2.2.jar
extensions/druid-examples/compress-lzf-1.0.3.jar
extensions/druid-examples/config-magic-0.9.jar
extensions/druid-examples/curator-client-2.9.1.jar
extensions/druid-examples/curator-framework-2.9.1.jar
extensions/druid-examples/curator-recipes-2.9.1.jar
extensions/druid-examples/curator-x-discovery-2.9.1.jar
extensions/druid-examples/disruptor-3.3.0.jar
extensions/druid-examples/druid-api-0.3.16.jar
extensions/druid-examples/druid-aws-common-0.9.0-rc3-SNAPSHOT.jar
extensions/druid-examples/druid-common-0.9.0-rc3-SNAPSHOT.jar
extensions/druid-examples/druid-console-0.0.2.jar
extensions/druid-examples/druid-processing-0.9.0-rc3-SNAPSHOT.jar
extensions/druid-examples/druid-server-0.9.0-rc3-SNAPSHOT.jar
extensions/druid-examples/emitter-0.3.6.jar
extensions/druid-examples/extendedset-1.3.9.jar
extensions/druid-examples/geoip2-0.4.0.jar
extensions/druid-examples/google-http-client-1.15.0-rc.jar
extensions/druid-examples/google-http-client-1.15.0-rc.jar
extensions/druid-examples/google-http-client-jackson2-1.15.0-rc.jar
extensions/druid-examples/google-http-client-jackson2-1.15.0-rc.jar
extensions/druid-examples/google-http-client-jackson2-1.15.0-rc.jar
extensions/druid-examples/guice-4.0-beta.jar
extensions/druid-examples/guice-multibindings-4.0-beta.jar
extensions/druid-examples/guice-multibindings-4.0-beta.jar
extensions/druid-examples/guice-servlet-4.0-beta.jar
extensions/druid-examples/guice-servlet-4.0-beta.jar
extensions/druid-examples/hibernate-validator-5.1.3.Final.jar
extensions/druid-examples/http-client-1.0.4.jar
extensions/druid-examples/httpclient-4.5.1.jar
extensions/druid-examples/httpcore-4.4.3.jar
extensions/druid-examples/icu4j-4.8.1.jar
extensions/druid-examples/irc-api-1.0-0014.jar
extensions/druid-examples/jackson-annotations-2.4.6.jar
extensions/druid-examples/jackson-annotations-2.4.6.jar
extensions/druid-examples/jackson-core-2.4.6.jar
extensions/druid-examples/jackson-core-asl-1.9.13.jar
extensions/druid-examples/jackson-core-asl-1.9.13.jar
extensions/druid-examples/jackson-databind-2.4.6.jar
extensions/druid-examples/jackson-dataformat-smile-2.4.6.jar
extensions/druid-examples/jackson-datatype-guava-2.4.6.jar
extensions/druid-examples/jackson-datatype-joda-2.4.6.jar
extensions/druid-examples/jackson-jaxrs-base-2.4.6.jar
extensions/druid-examples/jackson-jaxrs-json-provider-2.4.6.jar
extensions/druid-examples/jackson-jaxrs-smile-provider-2.4.6.jar
extensions/druid-examples/jackson-mapper-asl-1.9.13.jar
extensions/druid-examples/jackson-module-jaxb-annotations-2.4.6.jar
extensions/druid-examples/jackson-module-jaxb-annotations-2.4.6.jar
extensions/druid-examples/java-util-0.27.7.jar
extensions/druid-examples/java-xmlbuilder-1.1.jar
extensions/druid-examples/javax.el-3.0.0.jar
extensions/druid-examples/javax.el-api-3.0.0.jar
extensions/druid-examples/javax.el-api-3.0.0.jar
extensions/druid-examples/javax.servlet-api-3.1.0.jar
extensions/druid-examples/jboss-logging-3.1.3.GA.jar
extensions/druid-examples/jcl-over-slf4j-1.7.12.jar
extensions/druid-examples/jdbi-2.63.1.jar
extensions/druid-examples/jersey-core-1.19.jar
extensions/druid-examples/jersey-guice-1.19.jar
extensions/druid-examples/jersey-guice-1.19.jar
extensions/druid-examples/jersey-server-1.19.jar
extensions/druid-examples/jersey-servlet-1.19.jar
extensions/druid-examples/jets3t-0.9.4.jar
extensions/druid-examples/jetty-client-9.2.5.v20141112.jar
extensions/druid-examples/jetty-continuation-9.2.5.v20141112.jar
extensions/druid-examples/jetty-http-9.2.5.v20141112.jar
extensions/druid-examples/jetty-io-9.2.5.v20141112.jar
extensions/druid-examples/jetty-proxy-9.2.5.v20141112.jar
extensions/druid-examples/jetty-security-9.2.5.v20141112.jar
extensions/druid-examples/jetty-server-9.2.5.v20141112.jar
extensions/druid-examples/jetty-servlet-9.2.5.v20141112.jar
extensions/druid-examples/jetty-servlets-9.2.5.v20141112.jar
extensions/druid-examples/jetty-servlets-9.2.5.v20141112.jar
extensions/druid-examples/jetty-util-9.2.5.v20141112.jar
extensions/druid-examples/jline-0.9.94.jar
extensions/druid-examples/joda-time-2.8.2.jar
extensions/druid-examples/json-path-2.1.0.jar
extensions/druid-examples/jsr305-2.0.1.jar
extensions/druid-examples/jsr311-api-1.1.1.jar
extensions/druid-examples/log4j-1.2-api-2.5.jar
extensions/druid-examples/log4j-api-2.5.jar
extensions/druid-examples/log4j-api-2.5.jar
extensions/druid-examples/log4j-core-2.5.jar
extensions/druid-examples/log4j-core-2.5.jar
extensions/druid-examples/log4j-jul-2.5.jar
extensions/druid-examples/log4j-jul-2.5.jar
extensions/druid-examples/log4j-slf4j-impl-2.5.jar
extensions/druid-examples/log4j-slf4j-impl-2.5.jar
extensions/druid-examples/lz4-1.3.0.jar
extensions/druid-examples/mapdb-1.0.8.jar
extensions/druid-examples/maven-aether-provider-3.1.1.jar
extensions/druid-examples/maven-model-3.1.1.jar
extensions/druid-examples/maven-model-builder-3.1.1.jar
extensions/druid-examples/maven-model-builder-3.1.1.jar
extensions/druid-examples/maven-repository-metadata-3.1.1.jar
extensions/druid-examples/maven-settings-3.1.1.jar
extensions/druid-examples/maven-settings-builder-3.1.1.jar
extensions/druid-examples/maven-settings-builder-3.1.1.jar
extensions/druid-examples/maxminddb-0.2.0.jar
extensions/druid-examples/netty-3.10.4.Final.jar
extensions/druid-examples/okhttp-1.0.2.jar
extensions/druid-examples/opencsv-2.3.jar
extensions/druid-examples/org.abego.treelayout.core-1.0.1.jar
extensions/druid-examples/plexus-interpolation-1.19.jar
extensions/druid-examples/plexus-utils-3.0.15.jar
extensions/druid-examples/protobuf-java-2.5.0.jar
extensions/druid-examples/rhino-1.7R5.jar
extensions/druid-examples/server-metrics-0.2.8.jar
extensions/druid-examples/slf4j-api-1.7.12.jar
extensions/druid-examples/spymemcached-2.11.7.jar
extensions/druid-examples/tesla-aether-0.0.5.jar
extensions/druid-examples/validation-api-1.1.0.Final.jar
extensions/druid-examples/wagon-provider-api-2.4.jar
extensions/druid-examples/xpp3-1.1.4c.jar
extensions/druid-examples/zookeeper-3.4.6.jar
```