### PR TITLE
Distributed tasklockbox [don't merge]

### DIFF
--- a/common/src/main/java/io/druid/metadata/MetadataStorageActionHandler.java
+++ b/common/src/main/java/io/druid/metadata/MetadataStorageActionHandler.java
@@ -33,7 +33,7 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
   /**
    * Creates a new entry.
    * 
-   * @param id entry id
+   * @param entryId entry id
    * @param timestamp timestamp this entry was created
    * @param dataSource datasource associated with this entry
    * @param entry object representing this entry
@@ -42,7 +42,7 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
    * @throws EntryExistsException
    */
   void insert(
-      @NotNull String id,
+      @NotNull String entryId,
       @NotNull DateTime timestamp,
       @NotNull String dataSource,
       @NotNull EntryType entry,
@@ -145,24 +145,17 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
 
   /**
    * Returns owner for the given entry
-   * @param entryId
-   * @return
    */
   Optional<String> getOwner(String entryId);
 
   /**
    * Returns all locks acquired by active tasks with ownerId not equals to
    * the given ownerId
-   *
-   * @param ownerId
-   * @return
    */
   Map<Long, LockType> getRemoteActiveLocks(String ownerId);
 
   /**
-   * Take orphan tasks ownership
-   *
-   * @param ownerId
+   * Take ownership of all tasks that does not have owner
    */
-  void takeOrphanTasksOwnership(String ownerId);
+  void takeTasksOwnership(String ownerId);
 }

--- a/common/src/main/java/io/druid/metadata/MetadataStorageActionHandler.java
+++ b/common/src/main/java/io/druid/metadata/MetadataStorageActionHandler.java
@@ -41,13 +41,14 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
    * @param status status object associated wit this object, can be null
    * @throws EntryExistsException
    */
-  public void insert(
+  void insert(
       @NotNull String id,
       @NotNull DateTime timestamp,
       @NotNull String dataSource,
       @NotNull EntryType entry,
       boolean active,
-      @Nullable StatusType status
+      @Nullable StatusType status,
+      @Nullable String ownerId
   ) throws EntryExistsException;
 
 
@@ -60,7 +61,7 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
    * @param status status
    * @return true if the status was updated, false if the entry did not exist of if the entry was inactive
    */
-  public boolean setStatus(String entryId, boolean active, StatusType status);
+  boolean setStatus(String entryId, boolean active, StatusType status);
 
   /**
    * Retrieves the entry with the given id.
@@ -68,7 +69,7 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
    * @param entryId entry id
    * @return optional entry, absent if the given id does not exist
    */
-  public Optional<EntryType> getEntry(String entryId);
+  Optional<EntryType> getEntry(String entryId);
 
   /**
    * Retrieve the status for the entry with the given id.
@@ -76,14 +77,22 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
    * @param entryId entry id
    * @return optional status, absent if entry does not exist or status is not set
    */
-  public Optional<StatusType> getStatus(String entryId);
+  Optional<StatusType> getStatus(String entryId);
 
   /**
    * Return all active entries with their respective status
    *
    * @return list of (entry, status) pairs
    */
-  public List<Pair<EntryType, StatusType>> getActiveEntriesWithStatus();
+  List<Pair<EntryType, StatusType>> getActiveEntriesWithStatus();
+
+  /**
+   * Return active entries with their respective status for the provided ownerId
+   *
+   * @param ownerId owner id
+   * @return list of (entry, status) pairs
+   */
+  List<Pair<EntryType, StatusType>> getActiveEntriesWithStatus(String ownerId);
 
   /**
    * Return all statuses for inactive entries created on or later than the given timestamp
@@ -91,7 +100,7 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
    * @param timestamp timestamp
    * @return list of statuses
    */
-  public List<StatusType> getInactiveStatusesSince(DateTime timestamp);
+  List<StatusType> getInactiveStatusesSince(DateTime timestamp);
 
   /**
    * Add a lock to the given entry
@@ -100,14 +109,14 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
    * @param lock lock to add
    * @return true if the lock was added
    */
-  public boolean addLock(String entryId, LockType lock);
+  boolean addLock(String entryId, LockType lock);
 
   /**
    * Remove the lock with the given lock id.
    *
    * @param lockId lock id
    */
-  public void removeLock(long lockId);
+  void removeLock(long lockId);
 
   /**
    * Add a log to the entry with the given id.
@@ -116,7 +125,7 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
    * @param log log to add
    * @return true if the log was added
    */
-  public boolean addLog(String entryId, LogType log);
+  boolean addLog(String entryId, LogType log);
 
   /**
    * Returns the logs for the entry with the given id.
@@ -124,7 +133,7 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
    * @param entryId entry id
    * @return list of logs
    */
-  public List<LogType> getLogs(String entryId);
+  List<LogType> getLogs(String entryId);
 
   /**
    * Returns the locks for the given entry
@@ -132,5 +141,28 @@ public interface MetadataStorageActionHandler<EntryType, StatusType, LogType, Lo
    * @param entryId entry id
    * @return map of lockId to lock
    */
-  public Map<Long, LockType> getLocks(String entryId);
+  Map<Long, LockType> getLocks(String entryId);
+
+  /**
+   * Returns owner for the given entry
+   * @param entryId
+   * @return
+   */
+  Optional<String> getOwner(String entryId);
+
+  /**
+   * Returns all locks acquired by active tasks with ownerId not equals to
+   * the given ownerId
+   *
+   * @param ownerId
+   * @return
+   */
+  Map<Long, LockType> getRemoteActiveLocks(String ownerId);
+
+  /**
+   * Take orphan tasks ownership
+   *
+   * @param ownerId
+   */
+  void takeOrphanTasksOwnership(String ownerId);
 }

--- a/common/src/main/java/io/druid/metadata/MetadataStorageTablesConfig.java
+++ b/common/src/main/java/io/druid/metadata/MetadataStorageTablesConfig.java
@@ -31,7 +31,7 @@ public class MetadataStorageTablesConfig
 {
   public static MetadataStorageTablesConfig fromBase(String base)
   {
-    return new MetadataStorageTablesConfig(base, null, null, null, null, null, null, null, null, null, null);
+    return new MetadataStorageTablesConfig(base, null, null, null, null, null, null, null, null, null, null, null);
   }
 
   public static final String TASK_ENTRY_TYPE = "task";
@@ -41,6 +41,7 @@ public class MetadataStorageTablesConfig
   private final Map<String, String> entryTables = Maps.newHashMap();
   private final Map<String, String> logTables = Maps.newHashMap();
   private final Map<String, String> lockTables = Maps.newHashMap();
+  private final Map<String, String> ownerTables = Maps.newHashMap();
 
   @JsonProperty("base")
   private final String base;
@@ -69,6 +70,9 @@ public class MetadataStorageTablesConfig
   @JsonProperty("taskLock")
   private final String taskLockTable;
 
+  @JsonProperty("taskOwner")
+  private final String taskOwnerTable;
+
   @JsonProperty("audit")
   private final String auditTable;
 
@@ -86,6 +90,7 @@ public class MetadataStorageTablesConfig
       @JsonProperty("tasks") String tasksTable,
       @JsonProperty("taskLog") String taskLogTable,
       @JsonProperty("taskLock") String taskLockTable,
+      @JsonProperty("taskOwner") String taskOwnerTable,
       @JsonProperty("audit") String auditTable,
       @JsonProperty("supervisors") String supervisorTable
   )
@@ -100,9 +105,11 @@ public class MetadataStorageTablesConfig
     this.tasksTable = makeTableName(tasksTable, "tasks");
     this.taskLogTable = makeTableName(taskLogTable, "tasklogs");
     this.taskLockTable = makeTableName(taskLockTable, "tasklocks");
+    this.taskOwnerTable = makeTableName(taskOwnerTable, "taskowners");
     entryTables.put(TASK_ENTRY_TYPE, this.tasksTable);
     logTables.put(TASK_ENTRY_TYPE, this.taskLogTable);
     lockTables.put(TASK_ENTRY_TYPE, this.taskLockTable);
+    ownerTables.put(TASK_ENTRY_TYPE, this.taskOwnerTable);
     this.auditTable = makeTableName(auditTable, "audit");
     this.supervisorTable = makeTableName(supervisorTable, "supervisors");
   }
@@ -162,6 +169,10 @@ public class MetadataStorageTablesConfig
   public String getLockTable(final String entryType)
   {
     return lockTables.get(entryType);
+  }
+
+  public String getOwnerTable(final String entryType) {
+    return ownerTables.get(entryType);
   }
 
   public String getTaskEntryType()

--- a/extensions-contrib/sqlserver-metadata-storage/src/test/java/io/druid/metadata/storage/sqlserver/SQLServerConnectorTest.java
+++ b/extensions-contrib/sqlserver-metadata-storage/src/test/java/io/druid/metadata/storage/sqlserver/SQLServerConnectorTest.java
@@ -16,24 +16,26 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-package io.druid.metadata.storage.postgresql;
-
-import com.google.common.base.Suppliers;
-import io.druid.metadata.MetadataStorageConnectorConfig;
-import io.druid.metadata.MetadataStorageTablesConfig;
-import org.junit.Assert;
-import org.junit.Test;
+package io.druid.metadata.storage.sqlserver;
 
 import java.sql.SQLException;
 
-public class PostgreSQLConnectorTest
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.common.base.Suppliers;
+
+import io.druid.metadata.MetadataStorageConnectorConfig;
+import io.druid.metadata.MetadataStorageTablesConfig;
+
+@SuppressWarnings("nls")
+public class SQLServerConnectorTest
 {
 
   @Test
   public void testIsTransientException() throws Exception
   {
-    PostgreSQLConnector connector = new PostgreSQLConnector(
+    SQLServerConnector connector = new SQLServerConnector(
         Suppliers.ofInstance(new MetadataStorageConnectorConfig()),
         Suppliers.ofInstance(
             new MetadataStorageTablesConfig(
@@ -53,12 +55,15 @@ public class PostgreSQLConnectorTest
         )
     );
 
-    Assert.assertTrue(connector.isTransientException(new SQLException("bummer, connection problem", "08DIE")));
-    Assert.assertTrue(connector.isTransientException(new SQLException("bummer, too many things going on", "53RES")));
-    Assert.assertFalse(connector.isTransientException(new SQLException("oh god, no!", "58000")));
-    Assert.assertFalse(connector.isTransientException(new SQLException("help!")));
+    Assert.assertTrue(connector.isTransientException(new SQLException("Resource Failure!", "08DIE")));
+    Assert.assertTrue(connector.isTransientException(new SQLException("Resource Failure as well!", "53RES")));
+    Assert.assertTrue(connector.isTransientException(new SQLException("Transient Failures", "JW001")));
+    Assert.assertTrue(connector.isTransientException(new SQLException("Transient Rollback", "40001")));
+
+    Assert.assertFalse(connector.isTransientException(new SQLException("SQLException with reason only")));
     Assert.assertFalse(connector.isTransientException(new SQLException()));
-    Assert.assertFalse(connector.isTransientException(new Exception("I'm not happy")));
-    Assert.assertFalse(connector.isTransientException(new Throwable("I give up")));
+    Assert.assertFalse(connector.isTransientException(new Exception("Exception with reason only")));
+    Assert.assertFalse(connector.isTransientException(new Throwable("Throwable with reason only")));
   }
+
 }

--- a/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/KafkaIndexTaskTest.java
+++ b/extensions-core/kafka-indexing-service/src/test/java/io/druid/indexing/kafka/KafkaIndexTaskTest.java
@@ -70,6 +70,7 @@ import io.druid.indexing.common.config.TaskStorageConfig;
 import io.druid.indexing.common.task.Task;
 import io.druid.indexing.kafka.test.TestBroker;
 import io.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
+import io.druid.indexing.overlord.LocalTaskLockbox;
 import io.druid.indexing.overlord.MetadataTaskStorage;
 import io.druid.indexing.overlord.TaskLockbox;
 import io.druid.indexing.overlord.TaskStorage;
@@ -1368,7 +1369,7 @@ public class KafkaIndexTaskTest
     derbyConnector.createAuditTable();
     taskStorage = new MetadataTaskStorage(
         derbyConnector,
-        new TaskStorageConfig(null),
+        new TaskStorageConfig(null, null),
         new SQLMetadataStorageActionHandlerFactory(
             derbyConnector,
             derby.metadataTablesConfigSupplier().get(),
@@ -1380,7 +1381,7 @@ public class KafkaIndexTaskTest
         derby.metadataTablesConfigSupplier().get(),
         derbyConnector
     );
-    taskLockbox = new TaskLockbox(taskStorage);
+    taskLockbox = new LocalTaskLockbox(taskStorage);
     final TaskActionToolbox taskActionToolbox = new TaskActionToolbox(
         taskLockbox,
         metadataStorageCoordinator,

--- a/indexing-hadoop/src/main/java/io/druid/indexer/updater/MetadataStorageUpdaterJobSpec.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/updater/MetadataStorageUpdaterJobSpec.java
@@ -97,6 +97,7 @@ public class MetadataStorageUpdaterJobSpec implements Supplier<MetadataStorageCo
         null,
         null,
         null,
+        null,
         null
     );
   }

--- a/indexing-service/src/main/java/io/druid/indexing/common/config/TaskStorageConfig.java
+++ b/indexing-service/src/main/java/io/druid/indexing/common/config/TaskStorageConfig.java
@@ -28,22 +28,35 @@ import javax.validation.constraints.NotNull;
 
 public class TaskStorageConfig
 {
+  public static final String DEFAULT_TASK_OWNER_IR = "default";
+
   @JsonProperty
   @NotNull
-  public Duration recentlyFinishedThreshold = new Period("PT24H").toStandardDuration();
+  private Duration recentlyFinishedThreshold = new Period("PT24H").toStandardDuration();
+
+  @JsonProperty
+  private String taskOwnerId = DEFAULT_TASK_OWNER_IR;
 
   @JsonCreator
   public TaskStorageConfig(
-      @JsonProperty("recentlyFinishedThreshold") Period period
+      @JsonProperty("recentlyFinishedThreshold") Period period,
+      @JsonProperty("taskOwnerId") String taskOwnerId
   )
   {
     if(period != null) {
       this.recentlyFinishedThreshold = period.toStandardDuration();
+    }
+    if (taskOwnerId != null) {
+      this.taskOwnerId = taskOwnerId;
     }
   }
 
   public Duration getRecentlyFinishedThreshold()
   {
     return recentlyFinishedThreshold;
+  }
+
+  public String getTaskOwnerId() {
+    return taskOwnerId;
   }
 }

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/DistributedTaskLockbox.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/DistributedTaskLockbox.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.indexing.overlord;
+
+import com.google.common.base.Optional;
+import com.google.inject.Inject;
+import io.druid.indexing.common.TaskLock;
+import io.druid.indexing.common.task.Task;
+import org.joda.time.Interval;
+
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+/**
+ * Delegates all functionality to LocalTaskLockbox,
+ * makes additional check that lock is not acquired by RemoteTaskLockbox
+ */
+public class DistributedTaskLockbox implements TaskLockbox
+{
+  private static final int TASK_LOCKS_SIZE = 1000;
+
+  private final TaskStorage taskStorage;
+  private final TaskLockbox delegate;
+  private final LinkedHashSet<TaskLock> taskLocks;
+
+  @Inject
+  public DistributedTaskLockbox(
+      TaskStorage taskStorage
+  )
+  {
+    this.taskStorage = taskStorage;
+    this.delegate = new LocalTaskLockbox(taskStorage);
+    this.taskLocks = new LinkedHashSet<>(TASK_LOCKS_SIZE);
+  }
+
+  @Override
+  public void syncFromStorage()
+  {
+    delegate.syncFromStorage();
+  }
+
+  @Override
+  public TaskLock lock(
+      final Task task, final Interval interval
+  ) throws InterruptedException
+  {
+    Optional<TaskLock> taskLock = Optional.absent();
+    while (!taskLock.isPresent()) {
+      taskLock = tryLock(task, interval);
+      if (!taskLock.isPresent()) {
+        Thread.sleep(100);
+      }
+    }
+    return taskLock.get();
+  }
+
+  @Override
+  public Optional<TaskLock> tryLock(
+      final Task task, final Interval interval
+  )
+  {
+    return tryLock(task, interval, Optional.<String>absent());
+  }
+
+  @Override
+  public Optional<TaskLock> tryLock(
+      final Task task, final Interval interval, final Optional<String> preferredVersion
+  )
+  {
+    Optional<TaskLock> taskLock = delegate.tryLock(task, interval, preferredVersion);
+    if (taskLock.isPresent()) {
+      // checking remote locks is redundant if task has been added
+      // to the existing lock (with same group id)
+      if (!isExistedTaskLock(taskLock.get())) {
+        if (isLockedRemotely(task, interval)) {
+          delegate.unlock(task, interval);
+          return Optional.absent();
+        }
+        addTaskLock(taskLock.get());
+      }
+    }
+    return taskLock;
+  }
+
+  @Override
+  public void unlock(final Task task, final Interval interval)
+  {
+    delegate.unlock(task, interval);
+  }
+
+  @Override
+  public List<TaskLock> findLocksForTask(final Task task)
+  {
+    return delegate.findLocksForTask(task);
+  }
+
+  @Override
+  public void add(final Task task)
+  {
+    delegate.add(task);
+  }
+
+  @Override
+  public void remove(final Task task)
+  {
+    delegate.remove(task);
+  }
+
+  private boolean isLockedRemotely(final Task task, final Interval interval)
+  {
+    List<TaskLock> remoteTaskLocks = taskStorage.getRemoteActiveLocks();
+    for (TaskLock remoteTaskLock : remoteTaskLocks) {
+      if (remoteTaskLock.getDataSource().equals(task.getDataSource()) &&
+          remoteTaskLock.getInterval().overlaps(interval) &&
+          !remoteTaskLock.getGroupId().equals(task.getGroupId())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean isExistedTaskLock(TaskLock taskLock)
+  {
+    synchronized (taskLocks) {
+      return taskLocks.contains(taskLock);
+    }
+  }
+
+  private void addTaskLock(TaskLock taskLock)
+  {
+    synchronized (taskLocks) {
+      Iterator<TaskLock> it = taskLocks.iterator();
+      while (taskLocks.size() > TASK_LOCKS_SIZE) {
+        it.next();
+        it.remove();
+      }
+      taskLocks.add(taskLock);
+    }
+  }
+}

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/HeapMemoryTaskStorage.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/HeapMemoryTaskStorage.java
@@ -38,6 +38,7 @@ import io.druid.indexing.common.task.Task;
 import io.druid.metadata.EntryExistsException;
 import org.joda.time.DateTime;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
@@ -246,6 +247,12 @@ public class HeapMemoryTaskStorage implements TaskStorage
     } finally {
       giant.unlock();
     }
+  }
+
+  @Override
+  public List<TaskLock> getRemoteActiveLocks()
+  {
+    return Collections.emptyList();
   }
 
   private static class TaskStuff

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/LocalTaskLockbox.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/LocalTaskLockbox.java
@@ -1,0 +1,515 @@
+/*
+ * Licensed to Metamarkets Group Inc. (Metamarkets) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Metamarkets licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.druid.indexing.overlord;
+
+import com.google.common.base.Function;
+import com.google.common.base.Objects;
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Ordering;
+import com.google.common.collect.Sets;
+import com.google.inject.Inject;
+import com.metamx.emitter.EmittingLogger;
+import io.druid.common.utils.JodaUtils;
+import io.druid.indexing.common.TaskLock;
+import io.druid.indexing.common.task.Task;
+import com.metamx.common.ISE;
+import com.metamx.common.Pair;
+import com.metamx.common.guava.Comparators;
+import com.metamx.common.guava.FunctionalIterable;
+import org.joda.time.DateTime;
+import org.joda.time.Interval;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.NavigableSet;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Local implementation of {@link TaskLockbox}, persists acquired locks to {@link TaskStorage}
+ */
+public class LocalTaskLockbox implements TaskLockbox
+{
+  // Datasource -> Interval -> Tasks + TaskLock
+  private final Map<String, NavigableMap<Interval, TaskLockPosse>> running = Maps.newHashMap();
+  private final TaskStorage taskStorage;
+  private final ReentrantLock giant = new ReentrantLock(true);
+  private final Condition lockReleaseCondition = giant.newCondition();
+
+  private static final EmittingLogger log = new EmittingLogger(TaskLockbox.class);
+
+  // Stores List of Active Tasks. TaskLockbox will only grant locks to active activeTasks.
+  // this set should be accessed under the giant lock.
+  private final Set<String> activeTasks = Sets.newHashSet();
+
+  @Inject
+  public LocalTaskLockbox(
+      TaskStorage taskStorage
+  )
+  {
+    this.taskStorage = taskStorage;
+  }
+
+  @Override
+  public void syncFromStorage()
+  {
+    giant.lock();
+
+    try {
+      // Load stuff from taskStorage first. If this fails, we don't want to lose all our locks.
+      final Set<String> storedActiveTasks = Sets.newHashSet();
+      final List<Pair<Task, TaskLock>> storedLocks = Lists.newArrayList();
+      for (final Task task : taskStorage.getActiveTasks()) {
+        storedActiveTasks.add(task.getId());
+        for (final TaskLock taskLock : taskStorage.getLocks(task.getId())) {
+          storedLocks.add(Pair.of(task, taskLock));
+        }
+      }
+      // Sort locks by version, so we add them back in the order they were acquired.
+      final Ordering<Pair<Task, TaskLock>> byVersionOrdering = new Ordering<Pair<Task, TaskLock>>()
+      {
+        @Override
+        public int compare(Pair<Task, TaskLock> left, Pair<Task, TaskLock> right)
+        {
+          // The second compare shouldn't be necessary, but, whatever.
+          return ComparisonChain.start()
+                                .compare(left.rhs.getVersion(), right.rhs.getVersion())
+                                .compare(left.lhs.getId(), right.lhs.getId())
+                                .result();
+        }
+      };
+      running.clear();
+      activeTasks.clear();
+      activeTasks.addAll(storedActiveTasks);
+      // Bookkeeping for a log message at the end
+      int taskLockCount = 0;
+      for (final Pair<Task, TaskLock> taskAndLock : byVersionOrdering.sortedCopy(storedLocks)) {
+        final Task task = taskAndLock.lhs;
+        final TaskLock savedTaskLock = taskAndLock.rhs;
+        if (savedTaskLock.getInterval().toDurationMillis() <= 0) {
+          // "Impossible", but you never know what crazy stuff can be restored from storage.
+          log.warn("WTF?! Got lock with empty interval for task: %s", task.getId());
+          continue;
+        }
+        final Optional<TaskLock> acquiredTaskLock = tryLock(
+            task,
+            savedTaskLock.getInterval(),
+            Optional.of(savedTaskLock.getVersion())
+        );
+        if (acquiredTaskLock.isPresent() && savedTaskLock.getVersion().equals(acquiredTaskLock.get().getVersion())) {
+          taskLockCount ++;
+          log.info(
+              "Reacquired lock on interval[%s] version[%s] for task: %s",
+              savedTaskLock.getInterval(),
+              savedTaskLock.getVersion(),
+              task.getId()
+          );
+        } else if (acquiredTaskLock.isPresent()) {
+          taskLockCount ++;
+          log.info(
+              "Could not reacquire lock on interval[%s] version[%s] (got version[%s] instead) for task: %s",
+              savedTaskLock.getInterval(),
+              savedTaskLock.getVersion(),
+              acquiredTaskLock.get().getVersion(),
+              task.getId()
+          );
+        } else {
+          log.info(
+              "Could not reacquire lock on interval[%s] version[%s] for task: %s",
+              savedTaskLock.getInterval(),
+              savedTaskLock.getVersion(),
+              task.getId()
+          );
+        }
+      }
+      log.info(
+          "Synced %,d locks for %,d activeTasks from storage (%,d locks ignored).",
+          taskLockCount,
+          activeTasks.size(),
+          storedLocks.size() - taskLockCount
+      );
+    } finally {
+      giant.unlock();
+    }
+  }
+
+  @Override
+  public TaskLock lock(final Task task, final Interval interval) throws InterruptedException
+  {
+    giant.lock();
+    try {
+      Optional<TaskLock> taskLock;
+      while (!(taskLock = tryLock(task, interval)).isPresent()) {
+        lockReleaseCondition.await();
+      }
+
+      return taskLock.get();
+    } finally {
+      giant.unlock();
+    }
+  }
+
+  @Override
+  public Optional<TaskLock> tryLock(final Task task, final Interval interval)
+  {
+    return tryLock(task, interval, Optional.<String>absent());
+  }
+
+  @Override
+  public Optional<TaskLock> tryLock(final Task task, final Interval interval, final Optional<String> preferredVersion)
+  {
+    giant.lock();
+
+    try {
+      if(!activeTasks.contains(task.getId())){
+        throw new ISE("Unable to grant lock to inactive Task [%s]", task.getId());
+      }
+      Preconditions.checkArgument(interval.toDurationMillis() > 0, "interval empty");
+      final String dataSource = task.getDataSource();
+      final List<TaskLockPosse> foundPosses = findLockPossesForInterval(dataSource, interval);
+      final TaskLockPosse posseToUse;
+
+      if (foundPosses.size() > 1) {
+
+        // Too many existing locks.
+        return Optional.absent();
+
+      } else if (foundPosses.size() == 1) {
+
+        // One existing lock -- check if we can add to it.
+
+        final TaskLockPosse foundPosse = Iterables.getOnlyElement(foundPosses);
+        if (foundPosse.getTaskLock().getInterval().contains(interval) && foundPosse.getTaskLock().getGroupId().equals(task.getGroupId())) {
+          posseToUse = foundPosse;
+        } else {
+          return Optional.absent();
+        }
+
+      } else {
+
+        // No existing locks. We can make a new one.
+        if (!running.containsKey(dataSource)) {
+          running.put(dataSource, new TreeMap<Interval, TaskLockPosse>(Comparators.intervalsByStartThenEnd()));
+        }
+
+        // Create new TaskLock and assign it a version.
+        // Assumption: We'll choose a version that is greater than any previously-chosen version for our interval. (This
+        // may not always be true, unfortunately. See below.)
+
+        final String version;
+
+        if (preferredVersion.isPresent()) {
+          // We have a preferred version. We'll trust our caller to not break our ordering assumptions and just use it.
+          version = preferredVersion.get();
+        } else {
+          // We are running under an interval lock right now, so just using the current time works as long as we can trust
+          // our clock to be monotonic and have enough resolution since the last time we created a TaskLock for the same
+          // interval. This may not always be true; to assure it we would need to use some method of timekeeping other
+          // than the wall clock.
+          version = new DateTime().toString();
+        }
+
+        posseToUse = new TaskLockPosse(new TaskLock(task.getGroupId(), dataSource, interval, version));
+        running.get(dataSource)
+               .put(interval, posseToUse);
+
+        log.info("Created new TaskLockPosse: %s", posseToUse);
+      }
+
+      // Add to existing TaskLockPosse, if necessary
+      if (posseToUse.getTaskIds().add(task.getId())) {
+        log.info("Added task[%s] to TaskLock[%s]", task.getId(), posseToUse.getTaskLock().getGroupId());
+
+        // Update task storage facility. If it fails, revoke the lock.
+        try {
+          taskStorage.addLock(task.getId(), posseToUse.getTaskLock());
+          return Optional.of(posseToUse.getTaskLock());
+        } catch(Exception e) {
+          log.makeAlert("Failed to persist lock in storage")
+             .addData("task", task.getId())
+             .addData("dataSource", posseToUse.getTaskLock().getDataSource())
+             .addData("interval", posseToUse.getTaskLock().getInterval())
+             .addData("version", posseToUse.getTaskLock().getVersion())
+             .emit();
+          unlock(task, interval);
+          return Optional.absent();
+        }
+      } else {
+        log.info("Task[%s] already present in TaskLock[%s]", task.getId(), posseToUse.getTaskLock().getGroupId());
+        return Optional.of(posseToUse.getTaskLock());
+      }
+    }
+    finally {
+      giant.unlock();
+    }
+
+  }
+
+  @Override
+  public List<TaskLock> findLocksForTask(final Task task)
+  {
+    giant.lock();
+
+    try {
+      return Lists.transform(
+          findLockPossesForTask(task), new Function<TaskLockPosse, TaskLock>()
+          {
+            @Override
+            public TaskLock apply(TaskLockPosse taskLockPosse)
+            {
+              return taskLockPosse.getTaskLock();
+            }
+          }
+      );
+    } finally {
+      giant.unlock();
+    }
+  }
+
+  @Override
+  public void unlock(final Task task, final Interval interval)
+  {
+    giant.lock();
+
+    try {
+      final String dataSource = task.getDataSource();
+      final NavigableMap<Interval, TaskLockPosse> dsRunning = running.get(dataSource);
+
+      // So we can alert if activeTasks try to release stuff they don't have
+      boolean removed = false;
+
+      if(dsRunning != null) {
+        final TaskLockPosse taskLockPosse = dsRunning.get(interval);
+        if(taskLockPosse != null) {
+          final TaskLock taskLock = taskLockPosse.getTaskLock();
+
+          // Remove task from live list
+          log.info("Removing task[%s] from TaskLock[%s]", task.getId(), taskLock.getGroupId());
+          removed = taskLockPosse.getTaskIds().remove(task.getId());
+
+          if (taskLockPosse.getTaskIds().isEmpty()) {
+            log.info("TaskLock is now empty: %s", taskLock);
+            running.get(dataSource).remove(taskLock.getInterval());
+          }
+
+          if (running.get(dataSource).size() == 0) {
+            running.remove(dataSource);
+          }
+
+          // Wake up blocking-lock waiters
+          lockReleaseCondition.signalAll();
+
+          // Remove lock from storage. If it cannot be removed, just ignore the failure.
+          try {
+            taskStorage.removeLock(task.getId(), taskLock);
+          } catch(Exception e) {
+            log.makeAlert(e, "Failed to clean up lock from storage")
+               .addData("task", task.getId())
+               .addData("dataSource", taskLock.getDataSource())
+               .addData("interval", taskLock.getInterval())
+               .addData("version", taskLock.getVersion())
+               .emit();
+          }
+        }
+      }
+
+      if(!removed) {
+        log.makeAlert("Lock release without acquire")
+           .addData("task", task.getId())
+           .addData("interval", interval)
+           .emit();
+      }
+    } finally {
+      giant.unlock();
+    }
+  }
+
+  @Override
+  public void add(final Task task)
+  {
+    giant.lock();
+    try {
+      log.info("Adding task[%s] to activeTasks", task.getId());
+      activeTasks.add(task.getId());
+    } finally {
+      giant.unlock();
+    }
+  }
+
+  @Override
+  public void remove(final Task task)
+  {
+    giant.lock();
+    try {
+      try {
+        log.info("Removing task[%s] from activeTasks", task.getId());
+        for (final TaskLockPosse taskLockPosse : findLockPossesForTask(task)) {
+          unlock(task, taskLockPosse.getTaskLock().getInterval());
+        }
+      }
+      finally {
+        activeTasks.remove(task.getId());
+      }
+    }
+    finally {
+      giant.unlock();
+    }
+  }
+
+  /**
+   * Return the currently-active lock posses for some task.
+   *
+   * @param task task for which to locate locks
+   */
+  private List<TaskLockPosse> findLockPossesForTask(final Task task)
+  {
+    giant.lock();
+
+    try {
+      final Iterable<TaskLockPosse> searchSpace;
+
+      // Scan through all locks for this datasource
+      final NavigableMap<Interval, TaskLockPosse> dsRunning = running.get(task.getDataSource());
+      if(dsRunning == null) {
+        searchSpace = ImmutableList.of();
+      } else {
+        searchSpace = dsRunning.values();
+      }
+
+      return ImmutableList.copyOf(
+          Iterables.filter(
+              searchSpace, new Predicate<TaskLockPosse>()
+              {
+                @Override
+                public boolean apply(TaskLockPosse taskLock)
+                {
+                  return taskLock.getTaskIds().contains(task.getId());
+                }
+              }
+          )
+      );
+    }
+    finally {
+      giant.unlock();
+    }
+  }
+
+  /**
+   * Return all locks that overlap some search interval.
+   */
+  private List<TaskLockPosse> findLockPossesForInterval(final String dataSource, final Interval interval)
+  {
+    giant.lock();
+
+    try {
+      final NavigableMap<Interval, TaskLockPosse> dsRunning = running.get(dataSource);
+      if (dsRunning == null) {
+        // No locks at all
+        return Collections.emptyList();
+      } else {
+        // Tasks are indexed by locked interval, which are sorted by interval start. Intervals are non-overlapping, so:
+        final NavigableSet<Interval> dsLockbox = dsRunning.navigableKeySet();
+        final Iterable<Interval> searchIntervals = Iterables.concat(
+            // Single interval that starts at or before ours
+            Collections.singletonList(dsLockbox.floor(new Interval(interval.getStart(), new DateTime(JodaUtils.MAX_INSTANT)))),
+
+            // All intervals that start somewhere between our start instant (exclusive) and end instant (exclusive)
+            dsLockbox.subSet(
+                new Interval(interval.getStart(), new DateTime(JodaUtils.MAX_INSTANT)),
+                false,
+                new Interval(interval.getEnd(), interval.getEnd()),
+                false
+            )
+        );
+
+        return Lists.newArrayList(
+            FunctionalIterable
+                .create(searchIntervals)
+                .filter(
+                    new Predicate<Interval>()
+                    {
+                      @Override
+                      public boolean apply(@Nullable Interval searchInterval)
+                      {
+                        return searchInterval != null && searchInterval.overlaps(interval);
+                      }
+                    }
+                )
+                .transform(
+                    new Function<Interval, TaskLockPosse>()
+                    {
+                      @Override
+                      public TaskLockPosse apply(Interval interval)
+                      {
+                        return dsRunning.get(interval);
+                      }
+                    }
+                )
+        );
+      }
+    }
+    finally {
+      giant.unlock();
+    }
+  }
+
+  private static class TaskLockPosse
+  {
+    final private TaskLock taskLock;
+    final private Set<String> taskIds;
+
+    public TaskLockPosse(TaskLock taskLock)
+    {
+      this.taskLock = taskLock;
+      taskIds = Sets.newHashSet();
+    }
+
+    public TaskLock getTaskLock()
+    {
+      return taskLock;
+    }
+
+    public Set<String> getTaskIds()
+    {
+      return taskIds;
+    }
+
+    @Override
+    public String toString()
+    {
+      return Objects.toStringHelper(this)
+                    .add("taskLock", taskLock)
+                    .add("taskIds", taskIds)
+                    .toString();
+    }
+  }
+}

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/LocalTaskLockbox.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/LocalTaskLockbox.java
@@ -65,9 +65,9 @@ public class LocalTaskLockbox implements TaskLockbox
   private final ReentrantLock giant = new ReentrantLock(true);
   private final Condition lockReleaseCondition = giant.newCondition();
 
-  private static final EmittingLogger log = new EmittingLogger(TaskLockbox.class);
+  private static final EmittingLogger log = new EmittingLogger(LocalTaskLockbox.class);
 
-  // Stores List of Active Tasks. TaskLockbox will only grant locks to active activeTasks.
+  // Stores List of Active Tasks. LocalTaskLockbox will only grant locks to active activeTasks.
   // this set should be accessed under the giant lock.
   private final Set<String> activeTasks = Sets.newHashSet();
 

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/MetadataTaskStorage.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/MetadataTaskStorage.java
@@ -108,7 +108,7 @@ public class MetadataTaskStorage implements TaskStorage
   public void start()
   {
     metadataStorageConnector.createTaskTables();
-    handler.takeOrphanTasksOwnership(config.getTaskOwnerId());
+    handler.takeTasksOwnership(config.getTaskOwnerId());
   }
 
   @LifecycleStop
@@ -302,18 +302,11 @@ public class MetadataTaskStorage implements TaskStorage
   @Override
   public List<TaskLock> getRemoteActiveLocks()
   {
-    return ImmutableList.copyOf(
-        Iterables.transform(
-            handler.getRemoteActiveLocks(config.getTaskOwnerId()).entrySet(), new Function<Map.Entry<Long, TaskLock>, TaskLock>()
-            {
-              @Override
-              public TaskLock apply(Map.Entry<Long, TaskLock> e)
-              {
-                return e.getValue();
-              }
-            }
-        )
-    );
+    ImmutableList.Builder<TaskLock> taskLocks = ImmutableList.builder();
+    for (Map.Entry<Long, TaskLock> e : handler.getRemoteActiveLocks(config.getTaskOwnerId()).entrySet()) {
+      taskLocks.add(e.getValue());
+    }
+    return taskLocks.build();
   }
 
   private Map<Long, TaskLock> getLocksWithIds(final String taskid)

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/TaskLockbox.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/TaskLockbox.java
@@ -19,152 +19,24 @@
 
 package io.druid.indexing.overlord;
 
-import com.google.common.base.Function;
-import com.google.common.base.Objects;
 import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
-import com.google.common.collect.ComparisonChain;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Ordering;
-import com.google.common.collect.Sets;
-import com.google.inject.Inject;
-import com.metamx.common.ISE;
-import com.metamx.common.Pair;
-import com.metamx.common.guava.Comparators;
-import com.metamx.common.guava.FunctionalIterable;
-import com.metamx.emitter.EmittingLogger;
-import io.druid.common.utils.JodaUtils;
 import io.druid.indexing.common.TaskLock;
 import io.druid.indexing.common.task.Task;
-import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
-import javax.annotation.Nullable;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.NavigableMap;
-import java.util.NavigableSet;
-import java.util.Set;
-import java.util.TreeMap;
-import java.util.concurrent.locks.Condition;
-import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Remembers which activeTasks have locked which intervals. Tasks are permitted to lock an interval if no other task
  * outside their group has locked an overlapping interval for the same datasource. When a task locks an interval,
  * it is assigned a version string that it can use to publish segments.
  */
-public class TaskLockbox
+public interface TaskLockbox
 {
-  // Datasource -> Interval -> Tasks + TaskLock
-  private final Map<String, NavigableMap<Interval, TaskLockPosse>> running = Maps.newHashMap();
-  private final TaskStorage taskStorage;
-  private final ReentrantLock giant = new ReentrantLock();
-  private final Condition lockReleaseCondition = giant.newCondition();
-
-  private static final EmittingLogger log = new EmittingLogger(TaskLockbox.class);
-
-  // Stores List of Active Tasks. TaskLockbox will only grant locks to active activeTasks.
-  // this set should be accessed under the giant lock.
-  private final Set<String> activeTasks = Sets.newHashSet();
-
-  @Inject
-  public TaskLockbox(
-      TaskStorage taskStorage
-  )
-  {
-    this.taskStorage = taskStorage;
-  }
-
   /**
    * Wipe out our current in-memory state and resync it from our bundled {@link io.druid.indexing.overlord.TaskStorage}.
    */
-  public void syncFromStorage()
-  {
-    giant.lock();
-
-    try {
-      // Load stuff from taskStorage first. If this fails, we don't want to lose all our locks.
-      final Set<String> storedActiveTasks = Sets.newHashSet();
-      final List<Pair<Task, TaskLock>> storedLocks = Lists.newArrayList();
-      for (final Task task : taskStorage.getActiveTasks()) {
-        storedActiveTasks.add(task.getId());
-        for (final TaskLock taskLock : taskStorage.getLocks(task.getId())) {
-          storedLocks.add(Pair.of(task, taskLock));
-        }
-      }
-      // Sort locks by version, so we add them back in the order they were acquired.
-      final Ordering<Pair<Task, TaskLock>> byVersionOrdering = new Ordering<Pair<Task, TaskLock>>()
-      {
-        @Override
-        public int compare(Pair<Task, TaskLock> left, Pair<Task, TaskLock> right)
-        {
-          // The second compare shouldn't be necessary, but, whatever.
-          return ComparisonChain.start()
-                                .compare(left.rhs.getVersion(), right.rhs.getVersion())
-                                .compare(left.lhs.getId(), right.lhs.getId())
-                                .result();
-        }
-      };
-      running.clear();
-      activeTasks.clear();
-      activeTasks.addAll(storedActiveTasks);
-      // Bookkeeping for a log message at the end
-      int taskLockCount = 0;
-      for (final Pair<Task, TaskLock> taskAndLock : byVersionOrdering.sortedCopy(storedLocks)) {
-        final Task task = taskAndLock.lhs;
-        final TaskLock savedTaskLock = taskAndLock.rhs;
-        if (savedTaskLock.getInterval().toDurationMillis() <= 0) {
-          // "Impossible", but you never know what crazy stuff can be restored from storage.
-          log.warn("WTF?! Got lock with empty interval for task: %s", task.getId());
-          continue;
-        }
-        final Optional<TaskLock> acquiredTaskLock = tryLock(
-            task,
-            savedTaskLock.getInterval(),
-            Optional.of(savedTaskLock.getVersion())
-        );
-        if (acquiredTaskLock.isPresent() && savedTaskLock.getVersion().equals(acquiredTaskLock.get().getVersion())) {
-          taskLockCount ++;
-          log.info(
-              "Reacquired lock on interval[%s] version[%s] for task: %s",
-              savedTaskLock.getInterval(),
-              savedTaskLock.getVersion(),
-              task.getId()
-          );
-        } else if (acquiredTaskLock.isPresent()) {
-          taskLockCount ++;
-          log.info(
-              "Could not reacquire lock on interval[%s] version[%s] (got version[%s] instead) for task: %s",
-              savedTaskLock.getInterval(),
-              savedTaskLock.getVersion(),
-              acquiredTaskLock.get().getVersion(),
-              task.getId()
-          );
-        } else {
-          log.info(
-              "Could not reacquire lock on interval[%s] version[%s] for task: %s",
-              savedTaskLock.getInterval(),
-              savedTaskLock.getVersion(),
-              task.getId()
-          );
-        }
-      }
-      log.info(
-          "Synced %,d locks for %,d activeTasks from storage (%,d locks ignored).",
-          taskLockCount,
-          activeTasks.size(),
-          storedLocks.size() - taskLockCount
-      );
-    } finally {
-      giant.unlock();
-    }
-  }
+  void syncFromStorage();
 
   /**
    * Acquires a lock on behalf of a task. Blocks until the lock is acquired. Throws an exception if the lock
@@ -176,20 +48,7 @@ public class TaskLockbox
    *
    * @throws java.lang.InterruptedException if the lock cannot be acquired
    */
-  public TaskLock lock(final Task task, final Interval interval) throws InterruptedException
-  {
-    giant.lock();
-    try {
-      Optional<TaskLock> taskLock;
-      while (!(taskLock = tryLock(task, interval)).isPresent()) {
-        lockReleaseCondition.await();
-      }
-
-      return taskLock.get();
-    } finally {
-      giant.unlock();
-    }
-  }
+  TaskLock lock(final Task task, final Interval interval) throws InterruptedException;
 
   /**
    * Attempt to lock a task, without removing it from the queue. Equivalent to the long form of {@code tryLock}
@@ -201,10 +60,7 @@ public class TaskLockbox
    * @return lock version if lock was acquired, absent otherwise
    * @throws IllegalStateException if the task is not a valid active task
    */
-  public Optional<TaskLock> tryLock(final Task task, final Interval interval)
-  {
-    return tryLock(task, interval, Optional.<String>absent());
-  }
+  Optional<TaskLock> tryLock(final Task task, final Interval interval);
 
   /**
    * Attempt to lock a task, without removing it from the queue. Can safely be called multiple times on the same task.
@@ -220,120 +76,7 @@ public class TaskLockbox
    * @return lock version if lock was acquired, absent otherwise
    * @throws IllegalStateException if the task is not a valid active task
    */
-  private Optional<TaskLock> tryLock(final Task task, final Interval interval, final Optional<String> preferredVersion)
-  {
-    giant.lock();
-
-    try {
-      if(!activeTasks.contains(task.getId())){
-        throw new ISE("Unable to grant lock to inactive Task [%s]", task.getId());
-      }
-      Preconditions.checkArgument(interval.toDurationMillis() > 0, "interval empty");
-      final String dataSource = task.getDataSource();
-      final List<TaskLockPosse> foundPosses = findLockPossesForInterval(dataSource, interval);
-      final TaskLockPosse posseToUse;
-
-      if (foundPosses.size() > 1) {
-
-        // Too many existing locks.
-        return Optional.absent();
-
-      } else if (foundPosses.size() == 1) {
-
-        // One existing lock -- check if we can add to it.
-
-        final TaskLockPosse foundPosse = Iterables.getOnlyElement(foundPosses);
-        if (foundPosse.getTaskLock().getInterval().contains(interval) && foundPosse.getTaskLock().getGroupId().equals(task.getGroupId())) {
-          posseToUse = foundPosse;
-        } else {
-          return Optional.absent();
-        }
-
-      } else {
-
-        // No existing locks. We can make a new one.
-        if (!running.containsKey(dataSource)) {
-          running.put(dataSource, new TreeMap<Interval, TaskLockPosse>(Comparators.intervalsByStartThenEnd()));
-        }
-
-        // Create new TaskLock and assign it a version.
-        // Assumption: We'll choose a version that is greater than any previously-chosen version for our interval. (This
-        // may not always be true, unfortunately. See below.)
-
-        final String version;
-
-        if (preferredVersion.isPresent()) {
-          // We have a preferred version. We'll trust our caller to not break our ordering assumptions and just use it.
-          version = preferredVersion.get();
-        } else {
-          // We are running under an interval lock right now, so just using the current time works as long as we can trust
-          // our clock to be monotonic and have enough resolution since the last time we created a TaskLock for the same
-          // interval. This may not always be true; to assure it we would need to use some method of timekeeping other
-          // than the wall clock.
-          version = new DateTime().toString();
-        }
-
-        posseToUse = new TaskLockPosse(new TaskLock(task.getGroupId(), dataSource, interval, version));
-        running.get(dataSource)
-               .put(interval, posseToUse);
-
-        log.info("Created new TaskLockPosse: %s", posseToUse);
-      }
-
-      // Add to existing TaskLockPosse, if necessary
-      if (posseToUse.getTaskIds().add(task.getId())) {
-        log.info("Added task[%s] to TaskLock[%s]", task.getId(), posseToUse.getTaskLock().getGroupId());
-
-        // Update task storage facility. If it fails, revoke the lock.
-        try {
-          taskStorage.addLock(task.getId(), posseToUse.getTaskLock());
-          return Optional.of(posseToUse.getTaskLock());
-        } catch(Exception e) {
-          log.makeAlert("Failed to persist lock in storage")
-             .addData("task", task.getId())
-             .addData("dataSource", posseToUse.getTaskLock().getDataSource())
-             .addData("interval", posseToUse.getTaskLock().getInterval())
-             .addData("version", posseToUse.getTaskLock().getVersion())
-             .emit();
-          unlock(task, interval);
-          return Optional.absent();
-        }
-      } else {
-        log.info("Task[%s] already present in TaskLock[%s]", task.getId(), posseToUse.getTaskLock().getGroupId());
-        return Optional.of(posseToUse.getTaskLock());
-      }
-    }
-    finally {
-      giant.unlock();
-    }
-
-  }
-
-  /**
-   * Return the currently-active locks for some task.
-   *
-   * @param task task for which to locate locks
-   * @return currently-active locks for the given task
-   */
-  public List<TaskLock> findLocksForTask(final Task task)
-  {
-    giant.lock();
-
-    try {
-      return Lists.transform(
-          findLockPossesForTask(task), new Function<TaskLockPosse, TaskLock>()
-          {
-            @Override
-            public TaskLock apply(TaskLockPosse taskLockPosse)
-            {
-              return taskLockPosse.getTaskLock();
-            }
-          }
-      );
-    } finally {
-      giant.unlock();
-    }
-  }
+  Optional<TaskLock> tryLock(final Task task, final Interval interval, final Optional<String> preferredVersion);
 
   /**
    * Release lock held for a task on a particular interval. Does nothing if the task does not currently
@@ -342,223 +85,27 @@ public class TaskLockbox
    * @param task task to unlock
    * @param interval interval to unlock
    */
-  public void unlock(final Task task, final Interval interval)
-  {
-    giant.lock();
+  void unlock(final Task task, final Interval interval);
 
-    try {
-      final String dataSource = task.getDataSource();
-      final NavigableMap<Interval, TaskLockPosse> dsRunning = running.get(dataSource);
+  /**
+   * Return the currently-active locks for some task.
+   *
+   * @param task task for which to locate locks
+   * @return currently-active locks for the given task
+   */
+  List<TaskLock> findLocksForTask(final Task task);
 
-      // So we can alert if activeTasks try to release stuff they don't have
-      boolean removed = false;
-
-      if(dsRunning != null) {
-        final TaskLockPosse taskLockPosse = dsRunning.get(interval);
-        if(taskLockPosse != null) {
-          final TaskLock taskLock = taskLockPosse.getTaskLock();
-
-          // Remove task from live list
-          log.info("Removing task[%s] from TaskLock[%s]", task.getId(), taskLock.getGroupId());
-          removed = taskLockPosse.getTaskIds().remove(task.getId());
-
-          if (taskLockPosse.getTaskIds().isEmpty()) {
-            log.info("TaskLock is now empty: %s", taskLock);
-            running.get(dataSource).remove(taskLock.getInterval());
-          }
-
-          if (running.get(dataSource).size() == 0) {
-            running.remove(dataSource);
-          }
-
-          // Wake up blocking-lock waiters
-          lockReleaseCondition.signalAll();
-
-          // Remove lock from storage. If it cannot be removed, just ignore the failure.
-          try {
-            taskStorage.removeLock(task.getId(), taskLock);
-          } catch(Exception e) {
-            log.makeAlert(e, "Failed to clean up lock from storage")
-               .addData("task", task.getId())
-               .addData("dataSource", taskLock.getDataSource())
-               .addData("interval", taskLock.getInterval())
-               .addData("version", taskLock.getVersion())
-               .emit();
-          }
-        }
-      }
-
-      if(!removed) {
-        log.makeAlert("Lock release without acquire")
-           .addData("task", task.getId())
-           .addData("interval", interval)
-           .emit();
-      }
-    } finally {
-      giant.unlock();
-    }
-  }
+  /**
+   * Add task to active tasks, only active tasks are able to acquire a lock.
+   * @param task
+   */
+  void add(Task task);
 
   /**
    * Release all locks for a task and remove task from set of active tasks. Does nothing if the task is not currently locked or not an active task.
    *
    * @param task task to unlock
    */
-  public void remove(final Task task)
-  {
-    giant.lock();
-    try {
-      try {
-        log.info("Removing task[%s] from activeTasks", task.getId());
-        for (final TaskLockPosse taskLockPosse : findLockPossesForTask(task)) {
-          unlock(task, taskLockPosse.getTaskLock().getInterval());
-        }
-      }
-      finally {
-        activeTasks.remove(task.getId());
-      }
-    }
-    finally {
-      giant.unlock();
-    }
-  }
+  void remove(final Task task);
 
-  /**
-   * Return the currently-active lock posses for some task.
-   *
-   * @param task task for which to locate locks
-   */
-  private List<TaskLockPosse> findLockPossesForTask(final Task task)
-  {
-    giant.lock();
-
-    try {
-      final Iterable<TaskLockPosse> searchSpace;
-
-      // Scan through all locks for this datasource
-      final NavigableMap<Interval, TaskLockPosse> dsRunning = running.get(task.getDataSource());
-      if(dsRunning == null) {
-        searchSpace = ImmutableList.of();
-      } else {
-        searchSpace = dsRunning.values();
-      }
-
-      return ImmutableList.copyOf(
-          Iterables.filter(
-              searchSpace, new Predicate<TaskLockPosse>()
-          {
-            @Override
-            public boolean apply(TaskLockPosse taskLock)
-            {
-              return taskLock.getTaskIds().contains(task.getId());
-            }
-          }
-          )
-      );
-    }
-    finally {
-      giant.unlock();
-    }
-  }
-
-  /**
-   * Return all locks that overlap some search interval.
-   */
-  private List<TaskLockPosse> findLockPossesForInterval(final String dataSource, final Interval interval)
-  {
-    giant.lock();
-
-    try {
-      final NavigableMap<Interval, TaskLockPosse> dsRunning = running.get(dataSource);
-      if (dsRunning == null) {
-        // No locks at all
-        return Collections.emptyList();
-      } else {
-        // Tasks are indexed by locked interval, which are sorted by interval start. Intervals are non-overlapping, so:
-        final NavigableSet<Interval> dsLockbox = dsRunning.navigableKeySet();
-        final Iterable<Interval> searchIntervals = Iterables.concat(
-            // Single interval that starts at or before ours
-            Collections.singletonList(dsLockbox.floor(new Interval(interval.getStart(), new DateTime(JodaUtils.MAX_INSTANT)))),
-
-            // All intervals that start somewhere between our start instant (exclusive) and end instant (exclusive)
-            dsLockbox.subSet(
-                new Interval(interval.getStart(), new DateTime(JodaUtils.MAX_INSTANT)),
-                false,
-                new Interval(interval.getEnd(), interval.getEnd()),
-                false
-            )
-        );
-
-        return Lists.newArrayList(
-            FunctionalIterable
-                .create(searchIntervals)
-                .filter(
-                    new Predicate<Interval>()
-                    {
-                      @Override
-                      public boolean apply(@Nullable Interval searchInterval)
-                      {
-                        return searchInterval != null && searchInterval.overlaps(interval);
-                      }
-                    }
-                )
-                .transform(
-                    new Function<Interval, TaskLockPosse>()
-                    {
-                      @Override
-                      public TaskLockPosse apply(Interval interval)
-                      {
-                        return dsRunning.get(interval);
-                      }
-                    }
-                )
-        );
-      }
-    }
-    finally {
-      giant.unlock();
-    }
-  }
-
-  public void add(Task task)
-  {
-    giant.lock();
-    try {
-      log.info("Adding task[%s] to activeTasks", task.getId());
-      activeTasks.add(task.getId());
-    } finally {
-      giant.unlock();
-    }
-  }
-
-  private static class TaskLockPosse
-  {
-    final private TaskLock taskLock;
-    final private Set<String> taskIds;
-
-    public TaskLockPosse(TaskLock taskLock)
-    {
-      this.taskLock = taskLock;
-      taskIds = Sets.newHashSet();
-    }
-
-    public TaskLock getTaskLock()
-    {
-      return taskLock;
-    }
-
-    public Set<String> getTaskIds()
-    {
-      return taskIds;
-    }
-
-    @Override
-    public String toString()
-    {
-      return Objects.toStringHelper(this)
-                    .add("taskLock", taskLock)
-                    .add("taskIds", taskIds)
-                    .toString();
-    }
-  }
 }

--- a/indexing-service/src/main/java/io/druid/indexing/overlord/TaskStorage.java
+++ b/indexing-service/src/main/java/io/druid/indexing/overlord/TaskStorage.java
@@ -37,7 +37,7 @@ public interface TaskStorage
    * @param status task status
    * @throws io.druid.metadata.EntryExistsException if the task ID already exists
    */
-  public void insert(Task task, TaskStatus status) throws EntryExistsException;
+  void insert(Task task, TaskStatus status) throws EntryExistsException;
 
   /**
    * Persists task status in the storage facility. This method should throw an exception if the task status lifecycle
@@ -45,14 +45,14 @@ public interface TaskStorage
    *
    * @param status task status
    */
-  public void setStatus(TaskStatus status);
+  void setStatus(TaskStatus status);
 
   /**
    * Persists lock state in the storage facility.
    * @param taskid task ID
    * @param taskLock lock state
    */
-  public void addLock(String taskid, TaskLock taskLock);
+  void addLock(String taskid, TaskLock taskLock);
 
   /**
    * Removes lock state from the storage facility. It is harmless to keep old locks in the storage facility, but
@@ -61,7 +61,7 @@ public interface TaskStorage
    * @param taskid task ID
    * @param taskLock lock state
    */
-  public void removeLock(String taskid, TaskLock taskLock);
+  void removeLock(String taskid, TaskLock taskLock);
 
   /**
    * Returns task as stored in the storage facility. If the task ID does not exist, this will return an
@@ -72,7 +72,7 @@ public interface TaskStorage
    * @param taskid task ID
    * @return optional task
    */
-  public Optional<Task> getTask(String taskid);
+  Optional<Task> getTask(String taskid);
 
   /**
    * Returns task status as stored in the storage facility. If the task ID does not exist, this will return
@@ -81,7 +81,7 @@ public interface TaskStorage
    * @param taskid task ID
    * @return task status
    */
-  public Optional<TaskStatus> getStatus(String taskid);
+  Optional<TaskStatus> getStatus(String taskid);
 
   /**
    * Add an action taken by a task to the audit log.
@@ -91,7 +91,7 @@ public interface TaskStorage
    *
    * @param <T> task action return type
    */
-  public <T> void addAuditLog(Task task, TaskAction<T> taskAction);
+  <T> void addAuditLog(Task task, TaskAction<T> taskAction);
 
   /**
    * Returns all actions taken by a task.
@@ -99,7 +99,7 @@ public interface TaskStorage
    * @param taskid task ID
    * @return list of task actions
    */
-  public List<TaskAction> getAuditLogs(String taskid);
+  List<TaskAction> getAuditLogs(String taskid);
 
   /**
    * Returns a list of currently running or pending tasks as stored in the storage facility. No particular order
@@ -107,7 +107,7 @@ public interface TaskStorage
    *
    * @return list of active tasks
    */
-  public List<Task> getActiveTasks();
+  List<Task> getActiveTasks();
 
   /**
    * Returns a list of recently finished task statuses as stored in the storage facility. No particular order
@@ -116,7 +116,7 @@ public interface TaskStorage
    *
    * @return list of recently finished tasks
    */
-  public List<TaskStatus> getRecentlyFinishedTaskStatuses();
+  List<TaskStatus> getRecentlyFinishedTaskStatuses();
 
   /**
    * Returns a list of locks for a particular task.
@@ -124,5 +124,11 @@ public interface TaskStorage
    * @param taskid task ID
    * @return list of TaskLocks for the given task
    */
-  public List<TaskLock> getLocks(String taskid);
+  List<TaskLock> getLocks(String taskid);
+
+  /**
+   * Returns all locks acquired by not owned active tasks
+   * @return
+   */
+  List<TaskLock> getRemoteActiveLocks();
 }

--- a/indexing-service/src/test/java/io/druid/indexing/common/actions/TaskActionTestKit.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/actions/TaskActionTestKit.java
@@ -24,6 +24,7 @@ import io.druid.indexing.common.TestUtils;
 import io.druid.indexing.common.config.TaskStorageConfig;
 import io.druid.indexing.overlord.HeapMemoryTaskStorage;
 import io.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
+import io.druid.indexing.overlord.LocalTaskLockbox;
 import io.druid.indexing.overlord.TaskLockbox;
 import io.druid.indexing.overlord.TaskStorage;
 import io.druid.metadata.IndexerSQLMetadataStorageCoordinator;
@@ -77,8 +78,8 @@ public class TaskActionTestKit extends ExternalResource
   @Override
   public void before()
   {
-    taskStorage = new HeapMemoryTaskStorage(new TaskStorageConfig(new Period("PT24H")));
-    taskLockbox = new TaskLockbox(taskStorage);
+    taskStorage = new HeapMemoryTaskStorage(new TaskStorageConfig(new Period("PT24H"), null));
+    taskLockbox = new LocalTaskLockbox(taskStorage);
     testDerbyConnector = new TestDerbyConnector(
         Suppliers.ofInstance(new MetadataStorageConnectorConfig()),
         Suppliers.ofInstance(metadataStorageTablesConfig)

--- a/indexing-service/src/test/java/io/druid/indexing/common/task/RealtimeIndexTaskTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/common/task/RealtimeIndexTaskTest.java
@@ -63,6 +63,7 @@ import io.druid.indexing.common.config.TaskConfig;
 import io.druid.indexing.common.config.TaskStorageConfig;
 import io.druid.indexing.overlord.HeapMemoryTaskStorage;
 import io.druid.indexing.overlord.IndexerMetadataStorageCoordinator;
+import io.druid.indexing.overlord.LocalTaskLockbox;
 import io.druid.indexing.overlord.TaskLockbox;
 import io.druid.indexing.overlord.TaskStorage;
 import io.druid.indexing.test.TestDataSegmentAnnouncer;
@@ -663,7 +664,7 @@ public class RealtimeIndexTaskTest
   @Test(timeout = 60_000L)
   public void testRestoreAfterHandoffAttemptDuringShutdown() throws Exception
   {
-    final TaskStorage taskStorage = new HeapMemoryTaskStorage(new TaskStorageConfig(null));
+    final TaskStorage taskStorage = new HeapMemoryTaskStorage(new TaskStorageConfig(null, null));
     final TestIndexerMetadataStorageCoordinator mdc = new TestIndexerMetadataStorageCoordinator();
     final File directory = tempFolder.newFolder();
     final RealtimeIndexTask task1 = makeRealtimeTask(null);
@@ -936,7 +937,7 @@ public class RealtimeIndexTaskTest
   {
     return makeToolbox(
         task,
-        new HeapMemoryTaskStorage(new TaskStorageConfig(null)),
+        new HeapMemoryTaskStorage(new TaskStorageConfig(null, null)),
         mdc,
         directory
     );
@@ -950,7 +951,7 @@ public class RealtimeIndexTaskTest
   )
   {
     final TaskConfig taskConfig = new TaskConfig(directory.getPath(), null, null, 50000, null, false, null, null);
-    final TaskLockbox taskLockbox = new TaskLockbox(taskStorage);
+    final TaskLockbox taskLockbox = new LocalTaskLockbox(taskStorage);
     try {
       taskStorage.insert(task, TaskStatus.running(task.getId()));
     }

--- a/indexing-service/src/test/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactoryTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/firehose/IngestSegmentFirehoseFactoryTest.java
@@ -56,6 +56,7 @@ import io.druid.indexing.common.actions.TaskActionToolbox;
 import io.druid.indexing.common.config.TaskConfig;
 import io.druid.indexing.common.config.TaskStorageConfig;
 import io.druid.indexing.overlord.HeapMemoryTaskStorage;
+import io.druid.indexing.overlord.LocalTaskLockbox;
 import io.druid.indexing.overlord.TaskLockbox;
 import io.druid.metadata.IndexerSQLMetadataStorageCoordinator;
 import io.druid.query.aggregation.AggregatorFactory;
@@ -128,7 +129,7 @@ public class IngestSegmentFirehoseFactoryTest
     final IndexSpec indexSpec = new IndexSpec();
 
     final HeapMemoryTaskStorage ts = new HeapMemoryTaskStorage(
-        new TaskStorageConfig(null)
+        new TaskStorageConfig(null, null)
         {
         }
     );
@@ -158,7 +159,7 @@ public class IngestSegmentFirehoseFactoryTest
     }
     INDEX_MERGER.persist(index, persistDir, indexSpec);
 
-    final TaskLockbox tl = new TaskLockbox(ts);
+    final TaskLockbox tl = new LocalTaskLockbox(ts);
     final IndexerSQLMetadataStorageCoordinator mdc = new IndexerSQLMetadataStorageCoordinator(null, null, null)
     {
       final private Set<DataSegment> published = Sets.newHashSet();

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/LocalTaskLockboxTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/LocalTaskLockboxTest.java
@@ -30,9 +30,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.List;
 
-public class TaskLockboxTest
+public class LocalTaskLockboxTest
 {
   private TaskStorage taskStorage;
 
@@ -41,8 +40,8 @@ public class TaskLockboxTest
   @Before
   public void setUp()
   {
-    taskStorage = new HeapMemoryTaskStorage(new TaskStorageConfig(null));
-    lockbox = new TaskLockbox(taskStorage);
+    taskStorage = new HeapMemoryTaskStorage(new TaskStorageConfig(null, null));
+    lockbox = new LocalTaskLockbox(taskStorage);
   }
 
   @Test
@@ -125,6 +124,5 @@ public class TaskLockboxTest
     lockbox.remove(task);
     Assert.assertFalse(lockbox.tryLock(task, new Interval("2015-01-01/2015-01-02")).isPresent());
   }
-
 
 }

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/TaskLifecycleTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/TaskLifecycleTest.java
@@ -374,7 +374,7 @@ public class TaskLifecycleTest
     switch (taskStorageType) {
       case HEAP_TASK_STORAGE: {
         taskStorage = new HeapMemoryTaskStorage(
-            new TaskStorageConfig(null)
+            new TaskStorageConfig(null, null)
             {
             }
         );
@@ -391,7 +391,7 @@ public class TaskLifecycleTest
         testDerbyConnector.createSegmentTable();
         taskStorage = new MetadataTaskStorage(
             testDerbyConnector,
-            new TaskStorageConfig(null),
+            new TaskStorageConfig(null, null),
             new SQLMetadataStorageActionHandlerFactory(
                 testDerbyConnector,
                 derbyConnectorRule.metadataTablesConfigSupplier().get(),
@@ -505,7 +505,7 @@ public class TaskLifecycleTest
     Preconditions.checkNotNull(taskStorage);
     Preconditions.checkNotNull(emitter);
 
-    taskLockbox = new TaskLockbox(taskStorage);
+    taskLockbox = new LocalTaskLockbox(taskStorage);
     tac = new LocalTaskActionClientFactory(taskStorage, new TaskActionToolbox(taskLockbox, mdc, emitter));
     File tmpDir = temporaryFolder.newFolder();
     taskConfig = new TaskConfig(tmpDir.toString(), null, null, 50000, null, false, null, null);

--- a/indexing-service/src/test/java/io/druid/indexing/overlord/http/OverlordTest.java
+++ b/indexing-service/src/test/java/io/druid/indexing/overlord/http/OverlordTest.java
@@ -143,7 +143,7 @@ public class OverlordTest
             .andReturn(null).anyTimes();
     EasyMock.replay(taskLockbox, taskActionClientFactory);
 
-    taskStorage = new HeapMemoryTaskStorage(new TaskStorageConfig(null));
+    taskStorage = new HeapMemoryTaskStorage(new TaskStorageConfig(null, null));
     runTaskCountDownLatches = new CountDownLatch[2];
     runTaskCountDownLatches[0] = new CountDownLatch(1);
     runTaskCountDownLatches[1] = new CountDownLatch(1);

--- a/server/src/main/java/io/druid/metadata/SQLMetadataConnector.java
+++ b/server/src/main/java/io/druid/metadata/SQLMetadataConnector.java
@@ -367,6 +367,22 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
     );
   }
 
+  public void createOwnerTable(final String tableName, final String entryTypeName) {
+    createTable(
+        tableName,
+        ImmutableList.of(
+            String.format(
+                "CREATE TABLE %1$s (\n"
+                + "  %2$s_id VARCHAR(255) NOT NULL,\n"
+                + "  owner_id VARCHAR(255) NOT NULL,\n"
+                + "  PRIMARY KEY (%2$s_id)\n"
+                + ")",
+                tableName, entryTypeName
+            )
+        )
+    );
+  }
+
   public void createSupervisorsTable(final String tableName)
   {
     createTable(
@@ -486,6 +502,7 @@ public abstract class SQLMetadataConnector implements MetadataStorageConnector
       createEntryTable(tablesConfig.getEntryTable(entryType));
       createLogTable(tablesConfig.getLogTable(entryType), entryType);
       createLockTable(tablesConfig.getLockTable(entryType), entryType);
+      createOwnerTable(tablesConfig.getOwnerTable(entryType), entryType);
     }
   }
 

--- a/server/src/main/java/io/druid/metadata/SQLMetadataStorageActionHandler.java
+++ b/server/src/main/java/io/druid/metadata/SQLMetadataStorageActionHandler.java
@@ -39,6 +39,7 @@ import org.skife.jdbi.v2.exceptions.StatementException;
 import org.skife.jdbi.v2.tweak.HandleCallback;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
 import org.skife.jdbi.v2.util.ByteArrayMapper;
+import org.skife.jdbi.v2.util.StringMapper;
 
 import java.io.IOException;
 import java.sql.ResultSet;
@@ -62,6 +63,7 @@ public class SQLMetadataStorageActionHandler<EntryType, StatusType, LogType, Loc
   private final String entryTable;
   private final String logTable;
   private final String lockTable;
+  private final String entryOwnerTable;
 
   public SQLMetadataStorageActionHandler(
       final SQLMetadataConnector connector,
@@ -70,7 +72,8 @@ public class SQLMetadataStorageActionHandler<EntryType, StatusType, LogType, Loc
       final String entryTypeName,
       final String entryTable,
       final String logTable,
-      final String lockTable
+      final String lockTable,
+      final String entryOwnerTable
   )
   {
     this.connector = connector;
@@ -83,15 +86,18 @@ public class SQLMetadataStorageActionHandler<EntryType, StatusType, LogType, Loc
     this.entryTable = entryTable;
     this.logTable = logTable;
     this.lockTable = lockTable;
+    this.entryOwnerTable = entryOwnerTable;
   }
 
+  @Override
   public void insert(
       final String id,
       final DateTime timestamp,
       final String dataSource,
       final EntryType entry,
       final boolean active,
-      final StatusType status
+      final StatusType status,
+      final String ownerId
   ) throws EntryExistsException
   {
     try {
@@ -103,7 +109,19 @@ public class SQLMetadataStorageActionHandler<EntryType, StatusType, LogType, Loc
             {
               handle.createStatement(
                   String.format(
-                      "INSERT INTO %s (id, created_date, datasource, payload, active, status_payload) VALUES (:id, :created_date, :datasource, :payload, :active, :status_payload)",
+                      "INSERT INTO %s (%s_id, owner_id) VALUES (:id, :owner_id)",
+                      entryOwnerTable,
+                      entryTypeName
+                )
+              )
+                  .bind("id", id)
+                  .bind("owner_id", ownerId)
+                  .execute();
+
+              handle.createStatement(
+                  String.format(
+                      "INSERT INTO %s (id, created_date, datasource, payload, active, status_payload) "
+                      + "VALUES (:id, :created_date, :datasource, :payload, :active, :status_payload)",
                       entryTable
                   )
               )
@@ -142,6 +160,7 @@ public class SQLMetadataStorageActionHandler<EntryType, StatusType, LogType, Loc
     }
   }
 
+  @Override
   public boolean setStatus(final String entryId, final boolean active, final StatusType status)
   {
     return connector.retryWithHandle(
@@ -152,7 +171,8 @@ public class SQLMetadataStorageActionHandler<EntryType, StatusType, LogType, Loc
           {
             return handle.createStatement(
                 String.format(
-                    "UPDATE %s SET active = :active, status_payload = :status_payload WHERE id = :id AND active = TRUE",
+                    "UPDATE %s SET active = :active, status_payload = :status_payload "
+                    + "WHERE id = :id AND active = TRUE",
                     entryTable
                 )
             )
@@ -165,6 +185,7 @@ public class SQLMetadataStorageActionHandler<EntryType, StatusType, LogType, Loc
     );
   }
 
+  @Override
   public Optional<EntryType> getEntry(final String entryId)
   {
     return connector.retryWithHandle(
@@ -189,6 +210,7 @@ public class SQLMetadataStorageActionHandler<EntryType, StatusType, LogType, Loc
 
   }
 
+  @Override
   public Optional<StatusType> getStatus(final String entryId)
   {
     return connector.retryWithHandle(
@@ -212,6 +234,7 @@ public class SQLMetadataStorageActionHandler<EntryType, StatusType, LogType, Loc
     );
   }
 
+  @Override
   public List<Pair<EntryType, StatusType>> getActiveEntriesWithStatus()
   {
     return connector.retryWithHandle(
@@ -227,38 +250,41 @@ public class SQLMetadataStorageActionHandler<EntryType, StatusType, LogType, Loc
                         entryTable
                     )
                 )
-                .map(
-                    new ResultSetMapper<Pair<EntryType, StatusType>>()
-                    {
-                      @Override
-                      public Pair<EntryType, StatusType> map(int index, ResultSet r, StatementContext ctx)
-                          throws SQLException
-                      {
-                        try {
-                          return Pair.of(
-                              jsonMapper.<EntryType>readValue(
-                                  r.getBytes("payload"),
-                                  entryType
-                              ),
-                              jsonMapper.<StatusType>readValue(
-                                  r.getBytes("status_payload"),
-                                  statusType
-                              )
-                          );
-                        }
-                        catch (IOException e) {
-                          log.makeAlert(e, "Failed to parse entry payload").addData("entry", r.getString("id")).emit();
-                          throw new SQLException(e);
-                        }
-                      }
-                    }
-                ).list();
+                .map(new EntryAndStatusResultSetMapper())
+                .list();
           }
         }
     );
-
   }
 
+  @Override
+  public List<Pair<EntryType, StatusType>> getActiveEntriesWithStatus(final String ownerId)
+  {
+    return connector.retryWithHandle(
+        new HandleCallback<List<Pair<EntryType, StatusType>>>()
+        {
+          @Override
+          public List<Pair<EntryType, StatusType>> withHandle(Handle handle) throws Exception
+          {
+            return handle
+                .createQuery(
+                    String.format(
+                        "SELECT t.id, t.payload, t.status_payload FROM %s AS t, %s AS o "
+                        + "WHERE t.active = TRUE AND t.id = o.%s_id AND o.owner_id = '%s' ORDER BY t.created_date",
+                        entryTable,
+                        entryOwnerTable,
+                        entryTypeName,
+                        ownerId
+                    )
+                )
+                .map(new EntryAndStatusResultSetMapper())
+                .list();
+          }
+        }
+    );
+  }
+
+  @Override
   public List<StatusType> getInactiveStatusesSince(final DateTime timestamp)
   {
     return connector.retryWithHandle(
@@ -270,7 +296,8 @@ public class SQLMetadataStorageActionHandler<EntryType, StatusType, LogType, Loc
             return handle
                 .createQuery(
                     String.format(
-                        "SELECT id, status_payload FROM %s WHERE active = FALSE AND created_date >= :start ORDER BY created_date DESC",
+                        "SELECT id, status_payload FROM %s "
+                        + "WHERE active = FALSE AND created_date >= :start ORDER BY created_date DESC",
                         entryTable
                     )
                 ).bind("start", timestamp.toString())
@@ -300,6 +327,7 @@ public class SQLMetadataStorageActionHandler<EntryType, StatusType, LogType, Loc
     );
   }
 
+  @Override
   public boolean addLock(final String entryId, final LockType lock)
   {
     return connector.retryWithHandle(
@@ -322,6 +350,7 @@ public class SQLMetadataStorageActionHandler<EntryType, StatusType, LogType, Loc
     );
   }
 
+  @Override
   public void removeLock(final long lockId)
   {
     connector.retryWithHandle(
@@ -340,6 +369,7 @@ public class SQLMetadataStorageActionHandler<EntryType, StatusType, LogType, Loc
     );
   }
 
+  @Override
   public boolean addLog(final String entryId, final LogType log)
   {
     return connector.retryWithHandle(
@@ -362,6 +392,7 @@ public class SQLMetadataStorageActionHandler<EntryType, StatusType, LogType, Loc
     );
   }
 
+  @Override
   public List<LogType> getLogs(final String entryId)
   {
     return connector.retryWithHandle(
@@ -411,6 +442,7 @@ public class SQLMetadataStorageActionHandler<EntryType, StatusType, LogType, Loc
     );
   }
 
+  @Override
   public Map<Long, LockType> getLocks(final String entryId)
   {
     return connector.retryWithHandle(
@@ -426,34 +458,7 @@ public class SQLMetadataStorageActionHandler<EntryType, StatusType, LogType, Loc
                 )
             )
                          .bind("entryId", entryId)
-                         .map(
-                             new ResultSetMapper<Pair<Long, LockType>>()
-                             {
-                               @Override
-                               public Pair<Long, LockType> map(int index, ResultSet r, StatementContext ctx)
-                                   throws SQLException
-                               {
-                                 try {
-                                   return Pair.of(
-                                       r.getLong("id"),
-                                       jsonMapper.<LockType>readValue(
-                                           r.getBytes("lock_payload"),
-                                           lockType
-                                       )
-                                   );
-                                 }
-                                 catch (IOException e) {
-                                   log.makeAlert(e, "Failed to deserialize " + lockType.getType())
-                                      .addData("id", r.getLong("id"))
-                                      .addData(
-                                          "lockPayload", StringUtils.fromUtf8(r.getBytes("lock_payload"))
-                                      )
-                                      .emit();
-                                   throw new SQLException(e);
-                                 }
-                               }
-                             }
-                         )
+                         .map(new LockResultSetMapper())
                          .fold(
                              Maps.<Long, LockType>newLinkedHashMap(),
                              new Folder3<Map<Long, LockType>, Pair<Long, LockType>>()
@@ -475,4 +480,146 @@ public class SQLMetadataStorageActionHandler<EntryType, StatusType, LogType, Loc
         }
     );
   }
+
+  @Override
+  public Optional<String> getOwner(final String entryId)
+  {
+    String owner = connector.retryWithHandle(
+        new HandleCallback<String>()
+        {
+          @Override
+          public String withHandle(Handle handle) throws Exception
+          {
+            return handle.createQuery(
+                String.format(
+                    "SELECT owner_id FROM %1$s WHERE %2$s_id = :entryId",
+                    entryOwnerTable, entryTypeName
+                )
+            )
+                .bind("entryId", entryId)
+                .map(StringMapper.FIRST)
+                .first();
+          }
+        }
+    );
+    return (owner == null) ? Optional.<String>absent() : Optional.of(owner);
+  }
+
+  @Override
+  public Map<Long, LockType> getRemoteActiveLocks(final String ownerId)
+  {
+    return connector.retryWithHandle(
+        new HandleCallback<Map<Long, LockType>>()
+        {
+          @Override
+          public Map<Long, LockType> withHandle(Handle handle) throws Exception
+          {
+            return handle.createQuery(
+                String.format(
+                    "SELECT l.id, l.lock_payload FROM %1$s AS l, %2$s AS t, %3$s AS o "
+                    + "WHERE l.%4$s_id = t.%4$s_id AND t.%4$s_id = o.%4$s_id "
+                    + "AND t.active = TRUE AND o.owner_id != %5$s",
+                    lockTable, entryTable,
+                    entryOwnerTable, entryTypeName, ownerId
+                )
+            )
+                         .map(new LockResultSetMapper())
+                         .fold(
+                             Maps.<Long, LockType>newLinkedHashMap(),
+                             new Folder3<Map<Long, LockType>, Pair<Long, LockType>>()
+                             {
+                               @Override
+                               public Map<Long, LockType> fold(
+                                   Map<Long, LockType> accumulator,
+                                   Pair<Long, LockType> lock,
+                                   FoldController control,
+                                   StatementContext ctx
+                               ) throws SQLException
+                               {
+                                 accumulator.put(lock.lhs, lock.rhs);
+                                 return accumulator;
+                               }
+                             }
+                         );
+          }
+        }
+    );
+  }
+
+  @Override
+  public void takeOrphanTasksOwnership(final String ownerId)
+  {
+    connector.retryWithHandle(
+        new HandleCallback<Integer>()
+        {
+          @Override
+          public Integer withHandle(Handle handle) throws Exception
+          {
+            return handle.createStatement(
+                String.format(
+                   "INSERT INTO %1$s (%2$s_id, owner_id)"
+                   + "SELECT t.id, %3$s "
+                   + "FROM %4$s t LEFT JOIN %1$s o ON t.id = o.%2$s_id"
+                   + "WHERE t.active = TRUE AND o.%2$s_id IS NULL",
+                   entryOwnerTable,
+                   entryTypeName,
+                   ownerId,
+                   entryTable
+                )
+            ).execute();
+          }
+        }
+    );
+  }
+
+  private class EntryAndStatusResultSetMapper implements ResultSetMapper<Pair<EntryType, StatusType>> {
+    @Override
+    public Pair<EntryType, StatusType> map(int index, ResultSet r, StatementContext ctx)
+        throws SQLException
+    {
+      try {
+        return Pair.of(
+            jsonMapper.<EntryType>readValue(
+                r.getBytes("payload"),
+                entryType
+            ),
+            jsonMapper.<StatusType>readValue(
+                r.getBytes("status_payload"),
+                statusType
+            )
+        );
+      }
+      catch (IOException e) {
+        log.makeAlert(e, "Failed to parse entry payload").addData("entry", r.getString("id")).emit();
+        throw new SQLException(e);
+      }
+    }
+  }
+
+  private class LockResultSetMapper implements ResultSetMapper<Pair<Long, LockType>> {
+    @Override
+    public Pair<Long, LockType> map(int index, ResultSet r, StatementContext ctx)
+        throws SQLException
+    {
+      try {
+        return Pair.of(
+            r.getLong("id"),
+            jsonMapper.<LockType>readValue(
+                r.getBytes("lock_payload"),
+                lockType
+            )
+        );
+      }
+      catch (IOException e) {
+        log.makeAlert(e, "Failed to deserialize " + lockType.getType())
+           .addData("id", r.getLong("id"))
+           .addData(
+               "lockPayload", StringUtils.fromUtf8(r.getBytes("lock_payload"))
+           )
+           .emit();
+        throw new SQLException(e);
+      }
+    }
+  }
+
 }

--- a/server/src/main/java/io/druid/metadata/SQLMetadataStorageActionHandlerFactory.java
+++ b/server/src/main/java/io/druid/metadata/SQLMetadataStorageActionHandlerFactory.java
@@ -52,7 +52,8 @@ public class SQLMetadataStorageActionHandlerFactory implements MetadataStorageAc
         entryType,
         config.getEntryTable(entryType),
         config.getLogTable(entryType),
-        config.getLockTable(entryType)
+        config.getLockTable(entryType),
+        config.getOwnerTable(entryType)
     );
   }
 }

--- a/server/src/test/java/io/druid/metadata/SQLMetadataStorageActionHandlerTest.java
+++ b/server/src/test/java/io/druid/metadata/SQLMetadataStorageActionHandlerTest.java
@@ -57,11 +57,13 @@ public class SQLMetadataStorageActionHandlerTest
     final String entryTable = "entries";
     final String logTable = "logs";
     final String lockTable = "locks";
+    final String entryOwnerTable = "owners";
 
 
     connector.createEntryTable(entryTable);
     connector.createLockTable(lockTable, entryType);
     connector.createLogTable(logTable, entryType);
+    connector.createOwnerTable(entryOwnerTable, entryType);
 
 
     handler = new SQLMetadataStorageActionHandler<>(
@@ -104,7 +106,8 @@ public class SQLMetadataStorageActionHandlerTest
         entryType,
         entryTable,
         logTable,
-        lockTable
+        lockTable,
+        entryOwnerTable
     );
   }
 
@@ -116,19 +119,24 @@ public class SQLMetadataStorageActionHandlerTest
     Map<String, Integer> status2 = ImmutableMap.of("count", 42, "temp", 1);
 
     final String entryId = "1234";
+    final String ownerId = "owner";
 
-    handler.insert(entryId, new DateTime("2014-01-02T00:00:00.123"), "testDataSource", entry, true, null);
+    handler.insert(entryId, new DateTime("2014-01-02T00:00:00.123"), "testDataSource", entry, true, null, ownerId);
 
     Assert.assertEquals(
         Optional.of(entry),
         handler.getEntry(entryId)
     );
 
+    Assert.assertEquals(Optional.of(ownerId), handler.getOwner(entryId));
+
     Assert.assertEquals(Optional.absent(), handler.getEntry("non_exist_entry"));
 
     Assert.assertEquals(Optional.absent(), handler.getStatus(entryId));
 
     Assert.assertEquals(Optional.absent(), handler.getStatus("non_exist_entry"));
+
+    Assert.assertEquals(Optional.absent(), handler.getOwner("non_exist_entry"));
 
     Assert.assertTrue(handler.setStatus(entryId, true, status1));
 
@@ -187,10 +195,10 @@ public class SQLMetadataStorageActionHandlerTest
     Map<String, Integer> entry = ImmutableMap.of("a", 1);
     Map<String, Integer> status = ImmutableMap.of("count", 42);
 
-    handler.insert(entryId, new DateTime("2014-01-01"), "test", entry, true, status);
+    handler.insert(entryId, new DateTime("2014-01-01"), "test", entry, true, status, "owner");
 
     thrown.expect(EntryExistsException.class);
-    handler.insert(entryId, new DateTime("2014-01-01"), "test", entry, true, status);
+    handler.insert(entryId, new DateTime("2014-01-01"), "test", entry, true, status, "owner");
   }
 
   @Test
@@ -200,7 +208,7 @@ public class SQLMetadataStorageActionHandlerTest
     Map<String, Integer> entry = ImmutableMap.of("a", 1);
     Map<String, Integer> status = ImmutableMap.of("count", 42);
 
-    handler.insert(entryId, new DateTime("2014-01-01"), "test", entry, true, status);
+    handler.insert(entryId, new DateTime("2014-01-01"), "test", entry, true, status, "owner");
 
     Assert.assertEquals(
         ImmutableList.of(),
@@ -232,7 +240,7 @@ public class SQLMetadataStorageActionHandlerTest
     Map<String, Integer> entry = ImmutableMap.of("a", 1);
     Map<String, Integer> status = ImmutableMap.of("count", 42);
 
-    handler.insert(entryId, new DateTime("2014-01-01"), "test", entry, true, status);
+    handler.insert(entryId, new DateTime("2014-01-01"), "test", entry, true, status, "owner");
 
     Assert.assertEquals(
         ImmutableMap.<Long, Map<String, Integer>>of(),


### PR DESCRIPTION
DistributedTaskLockbox added as an attempt to allow running multiple Overlords simultaneously. The idea is to add an ownerId for tasks and corresponded locks. This gives an opportunity for multiple overlords to share metadata storage and check for remotely acquired locks once trying to acquire new lock for the interval.
TaskLockbox became interface and existed implementation renamed to LocalTaskLockbox.
The small optimization is to check whether new task has been added to locally existed taskLock (with the same groupId) to avoid remote locks checking which is quite expensive as it's done via metadata storage query.