### PR TITLE
Emitter upgrade from 0.4.0 to 0.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
             <dependency>
                 <groupId>com.metamx</groupId>
                 <artifactId>emitter</artifactId>
-                <version>0.4.0</version>
+                <version>0.4.1</version>
             </dependency>
             <dependency>
                 <groupId>com.metamx</groupId>


### PR DESCRIPTION
The compression was added to the new emitter 0.4.1.
This code change allows to use this feature to reduce emitter traffic.
You can turn it on by passing the following property into properties
druid.emitter.http.contentEncoding=GZIP