### PR TITLE
[BACKEND-784] Do not wait until all segments are moved in DruidCoordinatorBalancer

### DIFF
--- a/docs/content/configuration/coordinator.md
+++ b/docs/content/configuration/coordinator.md
@@ -87,7 +87,7 @@ Issuing a GET request at the same URL will return the spec that is currently in 
 |`millisToWaitBeforeDeleting`|How long does the coordinator need to be active before it can start removing (marking unused) segments in metadata storage.|900000 (15 mins)|
 |`mergeBytesLimit`|The maximum total uncompressed size in bytes of segments to merge.|524288000L|
 |`mergeSegmentsLimit`|The maximum number of segments that can be in a single [append task](../ingestion/tasks.html).|100|
-|`maxSegmentsToMove`|The maximum number of segments that can be moved at any given time.|5|
+|`maxSegmentsToMove`|The maximum number of segments that can be moved at any given time (per tier).|5|
 |`replicantLifetime`|The maximum number of coordinator runs for a segment to be replicated before we start alerting.|15|
 |`replicationThrottleLimit`|The maximum number of segments that can be replicated at one time.|10|
 |`emitBalancingStats`|Boolean flag for whether or not we should emit balancing stats. This is an expensive operation.|false|

--- a/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorBalancer.java
+++ b/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorBalancer.java
@@ -91,9 +91,9 @@ public class DruidCoordinatorBalancer implements DruidCoordinatorHelper
         params.getDruidCluster().getCluster().entrySet()) {
       String tier = entry.getKey();
 
-      currentlyMovingSegments.putIfAbsent(tier, new ConcurrentHashMap<>());
+      Map<String, BalancerSegmentHolder> tierMovingSegments = currentlyMovingSegments.computeIfAbsent(tier, key -> new ConcurrentHashMap<>());
 
-      final int numberOfMovingSegments = currentlyMovingSegments.get(tier).size();
+      final int numberOfMovingSegments = tierMovingSegments.size();
 
       if (numberOfMovingSegments > 0) {
         reduceLifetimes(tier);

--- a/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorBalancer.java
+++ b/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorBalancer.java
@@ -103,7 +103,7 @@ public class DruidCoordinatorBalancer implements DruidCoordinatorHelper
       final int segmentsToMove = maxSegmentsToMove - numberOfMovingSegments;
 
       if (segmentsToMove <= 0) {
-        log.info("[%s]: Too many segments are currently moving. Waiting.");
+        log.info("[%s]: Too many segments are currently moving. Waiting.", tier);
         continue;
       }
 

--- a/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorBalancer.java
+++ b/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorBalancer.java
@@ -91,13 +91,19 @@ public class DruidCoordinatorBalancer implements DruidCoordinatorHelper
         params.getDruidCluster().getCluster().entrySet()) {
       String tier = entry.getKey();
 
-      if (currentlyMovingSegments.get(tier) == null) {
-        currentlyMovingSegments.put(tier, new ConcurrentHashMap<String, BalancerSegmentHolder>());
+      currentlyMovingSegments.putIfAbsent(tier, new ConcurrentHashMap<>());
+
+      final int numberOfMovingSegments = currentlyMovingSegments.get(tier).size();
+
+      if (numberOfMovingSegments > 0) {
+        reduceLifetimes(tier);
+        log.info("[%s]: Still waiting on %,d segments to be moved", tier, numberOfMovingSegments);
       }
 
-      if (!currentlyMovingSegments.get(tier).isEmpty()) {
-        reduceLifetimes(tier);
-        log.info("[%s]: Still waiting on %,d segments to be moved", tier, currentlyMovingSegments.size());
+      final int segmentsToMove = maxSegmentsToMove - numberOfMovingSegments;
+
+      if (segmentsToMove <= 0) {
+        log.info("[%s]: Too many segments are currently moving. Waiting.");
         continue;
       }
 
@@ -118,32 +124,33 @@ public class DruidCoordinatorBalancer implements DruidCoordinatorHelper
         continue;
       }
       long unmoved = 0L;
-      for (int iter = 0; iter < maxSegmentsToMove; iter++) {
+      long moved = 0L;
+      for (int iter = 0; iter < segmentsToMove; iter++) {
         final BalancerSegmentHolder segmentToMove = strategy.pickSegmentToMove(serverHolderList);
 
         if (segmentToMove != null && params.getAvailableSegments().contains(segmentToMove.getSegment())) {
           final ServerHolder holder = strategy.findNewSegmentHomeBalancer(segmentToMove.getSegment(), serverHolderList);
 
-          if (holder != null) {
-            moveSegment(segmentToMove, holder.getServer(), params);
+          if (holder != null && moveSegment(segmentToMove, holder.getServer(), params)) {
+            ++moved;
           } else {
             ++unmoved;
           }
         }
       }
-      if (unmoved == maxSegmentsToMove) {
+      if (unmoved == segmentsToMove) {
         // Cluster should be alive and constantly adjusting
         log.info("No good moves found in tier [%s]", tier);
       }
       stats.addToTieredStat("unmovedCount", tier, unmoved);
-      stats.addToTieredStat("movedCount", tier, currentlyMovingSegments.get(tier).size());
+      stats.addToTieredStat("movedCount", tier, moved);
       if (params.getCoordinatorDynamicConfig().emitBalancingStats()) {
         strategy.emitStats(tier, stats, serverHolderList);
       }
       log.info(
           "[%s]: Segments Moved: [%d] Segments Let Alone: [%d]",
           tier,
-          currentlyMovingSegments.get(tier).size(),
+          moved,
           unmoved
       );
 
@@ -154,7 +161,7 @@ public class DruidCoordinatorBalancer implements DruidCoordinatorHelper
                  .build();
   }
 
-  protected void moveSegment(
+  protected boolean moveSegment(
       final BalancerSegmentHolder segment,
       final ImmutableDruidServer toServer,
       final DruidCoordinatorRuntimeParams params
@@ -191,6 +198,7 @@ public class DruidCoordinatorBalancer implements DruidCoordinatorHelper
             segmentToMove.getIdentifier(),
             callback
         );
+        return true;
       }
       catch (Exception e) {
         log.makeAlert(e, String.format("[%s] : Moving exception", segmentName)).emit();
@@ -201,6 +209,6 @@ public class DruidCoordinatorBalancer implements DruidCoordinatorHelper
     } else {
       currentlyMovingSegments.get(toServer.getTier()).remove(segmentName);
     }
-
+    return false;
   }
 }

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerTest.java
@@ -37,12 +37,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.MinMaxPriorityQueue;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.druid.client.ImmutableDruidServer;
+import io.druid.concurrent.Execs;
 import io.druid.timeline.DataSegment;
 import io.druid.timeline.partition.NoneShardSpec;
 import org.easymock.EasyMock;
@@ -41,7 +42,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -72,6 +72,16 @@ public class DruidCoordinatorBalancerTest
     segment2 = EasyMock.createMock(DataSegment.class);
     segment3 = EasyMock.createMock(DataSegment.class);
     segment4 = EasyMock.createMock(DataSegment.class);
+
+    // Mock stuff that the coordinator needs
+    coordinator.moveSegment(
+        EasyMock.<ImmutableDruidServer>anyObject(),
+        EasyMock.<ImmutableDruidServer>anyObject(),
+        EasyMock.<String>anyObject(),
+        EasyMock.<LoadPeonCallback>anyObject()
+    );
+    EasyMock.expectLastCall().anyTimes();
+    EasyMock.replay(coordinator);
 
     DateTime start1 = new DateTime("2012-01-01");
     DateTime start2 = new DateTime("2012-02-01");
@@ -142,79 +152,59 @@ public class DruidCoordinatorBalancerTest
   @Test
   public void testMoveToEmptyServerBalancer() throws IOException
   {
-    EasyMock.expect(druidServer1.getName()).andReturn("from").atLeastOnce();
-    EasyMock.expect(druidServer1.getTier()).andReturn("normal").anyTimes();
-    EasyMock.expect(druidServer1.getCurrSize()).andReturn(30L).atLeastOnce();
-    EasyMock.expect(druidServer1.getMaxSize()).andReturn(100L).atLeastOnce();
-    EasyMock.expect(druidServer1.getSegments()).andReturn(segments).anyTimes();
-    EasyMock.expect(druidServer1.getSegment(EasyMock.<String>anyObject())).andReturn(null).anyTimes();
-    EasyMock.replay(druidServer1);
-
-    EasyMock.expect(druidServer2.getName()).andReturn("to").atLeastOnce();
-    EasyMock.expect(druidServer2.getTier()).andReturn("normal").anyTimes();
-    EasyMock.expect(druidServer2.getCurrSize()).andReturn(0L).atLeastOnce();
-    EasyMock.expect(druidServer2.getMaxSize()).andReturn(100L).atLeastOnce();
-    EasyMock.expect(druidServer2.getSegments()).andReturn(new HashMap<String, DataSegment>()).anyTimes();
-    EasyMock.expect(druidServer2.getSegment(EasyMock.<String>anyObject())).andReturn(null).anyTimes();
-    EasyMock.replay(druidServer2);
+    mockDruidServer(druidServer1, "from", "normal", 30L, 100L, segments);
+    mockDruidServer(druidServer2, "to", "normal", 0L, 100L, new HashMap<>());
 
     EasyMock.replay(druidServer3);
     EasyMock.replay(druidServer4);
 
-    // Mock stuff that the coordinator needs
-    coordinator.moveSegment(
-        EasyMock.<ImmutableDruidServer>anyObject(),
-        EasyMock.<ImmutableDruidServer>anyObject(),
-        EasyMock.<String>anyObject(),
-        EasyMock.<LoadPeonCallback>anyObject()
-    );
-    EasyMock.expectLastCall().anyTimes();
-    EasyMock.replay(coordinator);
 
     LoadQueuePeonTester fromPeon = new LoadQueuePeonTester();
     LoadQueuePeonTester toPeon = new LoadQueuePeonTester();
+
     ListeningExecutorService exec = MoreExecutors.listeningDecorator(
-            Executors.newFixedThreadPool(1));
+        Execs.singleThreaded("balancer-strategy-exec"));
     BalancerStrategy balancerStrategy =
-            new CostBalancerStrategyFactory().createBalancerStrategy(exec);
+        new CostBalancerStrategyFactory().createBalancerStrategy(exec);
 
     DruidCoordinatorRuntimeParams params =
-        DruidCoordinatorRuntimeParams.newBuilder()
-                                .withDruidCluster(
-                                    new DruidCluster(
-                                        ImmutableMap.<String, MinMaxPriorityQueue<ServerHolder>>of(
-                                            "normal",
-                                            MinMaxPriorityQueue.orderedBy(DruidCoordinatorBalancerTester.percentUsedComparator)
-                                                               .create(
-                                                                   Arrays.asList(
-                                                                       new ServerHolder(druidServer1, fromPeon),
-                                                                       new ServerHolder(druidServer2, toPeon)
-                                                                   )
-                                                               )
-                                        )
-                                    )
+        DruidCoordinatorRuntimeParams
+            .newBuilder()
+            .withDruidCluster(
+                new DruidCluster(
+                    ImmutableMap.<String, MinMaxPriorityQueue<ServerHolder>>of(
+                        "normal",
+                        MinMaxPriorityQueue
+                            .orderedBy(DruidCoordinatorBalancerTester.percentUsedComparator)
+                            .create(
+                                Arrays.asList(
+                                    new ServerHolder(druidServer1, fromPeon),
+                                    new ServerHolder(druidServer2, toPeon)
                                 )
-                                .withLoadManagementPeons(
-                                    ImmutableMap.<String, LoadQueuePeon>of(
-                                        "from",
-                                        fromPeon,
-                                        "to",
-                                        toPeon
-                                    )
-                                )
-                                .withAvailableSegments(segments.values())
-                                .withDynamicConfigs(
-                                    new CoordinatorDynamicConfig.Builder().withMaxSegmentsToMove(
-                                        MAX_SEGMENTS_TO_MOVE
-                                    ).build()
-                                )
-                                     .withBalancerStrategy(balancerStrategy)
-                                     .withBalancerReferenceTimestamp(new DateTime("2013-01-01"))
-                                .build();
+                            )
+                    )
+                )
+            )
+            .withLoadManagementPeons(
+                ImmutableMap.<String, LoadQueuePeon>of(
+                    "from", fromPeon,
+                    "to", toPeon
+                )
+            )
+            .withAvailableSegments(segments.values())
+            .withDynamicConfigs(
+                new CoordinatorDynamicConfig.Builder().withMaxSegmentsToMove(
+                    MAX_SEGMENTS_TO_MOVE
+                ).build()
+            )
+            .withBalancerStrategy(balancerStrategy)
+            .withBalancerReferenceTimestamp(new DateTime("2013-01-01"))
+            .build();
 
     params = new DruidCoordinatorBalancerTester(coordinator).run(params);
     Assert.assertTrue(params.getCoordinatorStats().getPerTierStats().get("movedCount").get("normal").get() > 0);
-    Assert.assertTrue(params.getCoordinatorStats().getPerTierStats().get("movedCount").get("normal").get() < segments.size());
+    Assert.assertTrue(params.getCoordinatorStats().getPerTierStats().get("movedCount").get("normal").get()
+                      < segments.size());
     exec.shutdown();
   }
 
@@ -224,74 +214,52 @@ public class DruidCoordinatorBalancerTest
   {
     // Mock some servers of different usages
 
-    EasyMock.expect(druidServer1.getName()).andReturn("from").atLeastOnce();
-    EasyMock.expect(druidServer1.getTier()).andReturn("normal").anyTimes();
-    EasyMock.expect(druidServer1.getCurrSize()).andReturn(30L).atLeastOnce();
-    EasyMock.expect(druidServer1.getMaxSize()).andReturn(100L).atLeastOnce();
-    EasyMock.expect(druidServer1.getSegments()).andReturn(segments).anyTimes();
-    EasyMock.expect(druidServer1.getSegment(EasyMock.<String>anyObject())).andReturn(null).anyTimes();
-    EasyMock.replay(druidServer1);
-
-    EasyMock.expect(druidServer2.getName()).andReturn("to").atLeastOnce();
-    EasyMock.expect(druidServer2.getTier()).andReturn("normal").anyTimes();
-    EasyMock.expect(druidServer2.getCurrSize()).andReturn(0L).atLeastOnce();
-    EasyMock.expect(druidServer2.getMaxSize()).andReturn(100L).atLeastOnce();
-    EasyMock.expect(druidServer2.getSegments()).andReturn(new HashMap<String, DataSegment>()).anyTimes();
-    EasyMock.expect(druidServer2.getSegment(EasyMock.<String>anyObject())).andReturn(null).anyTimes();
-    EasyMock.replay(druidServer2);
+    mockDruidServer(druidServer1, "from", "normal", 30L, 100L, segments);
+    mockDruidServer(druidServer2, "to", "normal", 0L, 100L, new HashMap<>());
 
     EasyMock.replay(druidServer3);
     EasyMock.replay(druidServer4);
 
-    // Mock stuff that the coordinator needs
-    coordinator.moveSegment(
-        EasyMock.<ImmutableDruidServer>anyObject(),
-        EasyMock.<ImmutableDruidServer>anyObject(),
-        EasyMock.<String>anyObject(),
-        EasyMock.<LoadPeonCallback>anyObject()
-    );
-    EasyMock.expectLastCall().anyTimes();
-    EasyMock.replay(coordinator);
-
     ListeningExecutorService exec = MoreExecutors.listeningDecorator(
-            Executors.newFixedThreadPool(1));
+        Execs.singleThreaded("balancer-strategy-exec"));
     BalancerStrategy balancerStrategy =
-            new CostBalancerStrategyFactory().createBalancerStrategy(exec);
+        new CostBalancerStrategyFactory().createBalancerStrategy(exec);
 
     LoadQueuePeonTester fromPeon = new LoadQueuePeonTester();
     LoadQueuePeonTester toPeon = new LoadQueuePeonTester();
     DruidCoordinatorRuntimeParams params =
-        DruidCoordinatorRuntimeParams.newBuilder()
-                                .withDruidCluster(
-                                    new DruidCluster(
-                                        ImmutableMap.<String, MinMaxPriorityQueue<ServerHolder>>of(
-                                            "normal",
-                                            MinMaxPriorityQueue.orderedBy(DruidCoordinatorBalancerTester.percentUsedComparator)
-                                                               .create(
-                                                                   Arrays.asList(
-                                                                       new ServerHolder(druidServer1, fromPeon),
-                                                                       new ServerHolder(druidServer2, toPeon)
-                                                                   )
-                                                               )
-                                        )
-                                    )
+        DruidCoordinatorRuntimeParams
+            .newBuilder()
+            .withDruidCluster(
+                new DruidCluster(
+                    ImmutableMap.<String, MinMaxPriorityQueue<ServerHolder>>of(
+                        "normal",
+                        MinMaxPriorityQueue
+                            .orderedBy(DruidCoordinatorBalancerTester.percentUsedComparator)
+                            .create(
+                                Arrays.asList(
+                                    new ServerHolder(druidServer1, fromPeon),
+                                    new ServerHolder(druidServer2, toPeon)
                                 )
-                                .withLoadManagementPeons(
-                                    ImmutableMap.<String, LoadQueuePeon>of(
-                                        "from",
-                                        fromPeon,
-                                        "to",
-                                        toPeon
-                                    )
-                                )
-                                .withAvailableSegments(segments.values())
-                                .withDynamicConfigs(
-                                    new CoordinatorDynamicConfig.Builder().withMaxSegmentsToMove(MAX_SEGMENTS_TO_MOVE)
-                                                                     .build()
-                                )
-                                     .withBalancerStrategy(balancerStrategy)
-                                     .withBalancerReferenceTimestamp(new DateTime("2013-01-01"))
-                                .build();
+                            )
+                    )
+                )
+            )
+            .withLoadManagementPeons(
+                ImmutableMap.<String, LoadQueuePeon>of(
+                    "from", fromPeon,
+                    "to", toPeon
+                )
+            )
+            .withAvailableSegments(segments.values())
+            .withDynamicConfigs(
+                new CoordinatorDynamicConfig.Builder().withMaxSegmentsToMove(
+                    MAX_SEGMENTS_TO_MOVE)
+                                                      .build()
+            )
+            .withBalancerStrategy(balancerStrategy)
+            .withBalancerReferenceTimestamp(new DateTime("2013-01-01"))
+            .build();
 
     params = new DruidCoordinatorBalancerTester(coordinator).run(params);
     Assert.assertTrue(params.getCoordinatorStats().getPerTierStats().get("movedCount").get("normal").get() > 0);
@@ -303,47 +271,10 @@ public class DruidCoordinatorBalancerTest
   public void testRun2() throws IOException
   {
     // Mock some servers of different usages
-    EasyMock.expect(druidServer1.getName()).andReturn("1").atLeastOnce();
-    EasyMock.expect(druidServer1.getTier()).andReturn("normal").anyTimes();
-    EasyMock.expect(druidServer1.getCurrSize()).andReturn(30L).atLeastOnce();
-    EasyMock.expect(druidServer1.getMaxSize()).andReturn(100L).atLeastOnce();
-    EasyMock.expect(druidServer1.getSegments()).andReturn(segments).anyTimes();
-    EasyMock.expect(druidServer1.getSegment(EasyMock.<String>anyObject())).andReturn(null).anyTimes();
-    EasyMock.replay(druidServer1);
-
-    EasyMock.expect(druidServer2.getName()).andReturn("2").atLeastOnce();
-    EasyMock.expect(druidServer2.getTier()).andReturn("normal").anyTimes();
-    EasyMock.expect(druidServer2.getCurrSize()).andReturn(0L).atLeastOnce();
-    EasyMock.expect(druidServer2.getMaxSize()).andReturn(100L).atLeastOnce();
-    EasyMock.expect(druidServer2.getSegments()).andReturn(new HashMap<String, DataSegment>()).anyTimes();
-    EasyMock.expect(druidServer2.getSegment(EasyMock.<String>anyObject())).andReturn(null).anyTimes();
-    EasyMock.replay(druidServer2);
-
-    EasyMock.expect(druidServer3.getName()).andReturn("3").atLeastOnce();
-    EasyMock.expect(druidServer3.getTier()).andReturn("normal").anyTimes();
-    EasyMock.expect(druidServer3.getCurrSize()).andReturn(0L).atLeastOnce();
-    EasyMock.expect(druidServer3.getMaxSize()).andReturn(100L).atLeastOnce();
-    EasyMock.expect(druidServer3.getSegments()).andReturn(new HashMap<String, DataSegment>()).anyTimes();
-    EasyMock.expect(druidServer3.getSegment(EasyMock.<String>anyObject())).andReturn(null).anyTimes();
-    EasyMock.replay(druidServer3);
-
-    EasyMock.expect(druidServer4.getName()).andReturn("4").atLeastOnce();
-    EasyMock.expect(druidServer4.getTier()).andReturn("normal").anyTimes();
-    EasyMock.expect(druidServer4.getCurrSize()).andReturn(0L).atLeastOnce();
-    EasyMock.expect(druidServer4.getMaxSize()).andReturn(100L).atLeastOnce();
-    EasyMock.expect(druidServer4.getSegments()).andReturn(new HashMap<String, DataSegment>()).anyTimes();
-    EasyMock.expect(druidServer4.getSegment(EasyMock.<String>anyObject())).andReturn(null).anyTimes();
-    EasyMock.replay(druidServer4);
-
-    // Mock stuff that the coordinator needs
-    coordinator.moveSegment(
-        EasyMock.<ImmutableDruidServer>anyObject(),
-        EasyMock.<ImmutableDruidServer>anyObject(),
-        EasyMock.<String>anyObject(),
-        EasyMock.<LoadPeonCallback>anyObject()
-    );
-    EasyMock.expectLastCall().anyTimes();
-    EasyMock.replay(coordinator);
+    mockDruidServer(druidServer1, "1", "normal", 30L, 100L, segments);
+    mockDruidServer(druidServer2, "2", "normal", 0L, 100L, new HashMap<>());
+    mockDruidServer(druidServer3, "3", "normal", 0L, 100L, new HashMap<>());
+    mockDruidServer(druidServer4, "4", "normal", 0L, 100L, new HashMap<>());
 
     LoadQueuePeonTester peon1 = new LoadQueuePeonTester();
     LoadQueuePeonTester peon2 = new LoadQueuePeonTester();
@@ -351,49 +282,47 @@ public class DruidCoordinatorBalancerTest
     LoadQueuePeonTester peon4 = new LoadQueuePeonTester();
 
     ListeningExecutorService exec = MoreExecutors.listeningDecorator(
-            Executors.newFixedThreadPool(1));
+        Execs.singleThreaded("balancer-strategy-exec"));
     BalancerStrategy balancerStrategy =
-            new CostBalancerStrategyFactory().createBalancerStrategy(exec);
+        new CostBalancerStrategyFactory().createBalancerStrategy(exec);
 
     DruidCoordinatorRuntimeParams params =
-        DruidCoordinatorRuntimeParams.newBuilder()
-                                .withDruidCluster(
-                                    new DruidCluster(
-                                        ImmutableMap.<String, MinMaxPriorityQueue<ServerHolder>>of(
-                                            "normal",
-                                            MinMaxPriorityQueue.orderedBy(DruidCoordinatorBalancerTester.percentUsedComparator)
-                                                               .create(
-                                                                   Arrays.asList(
-                                                                       new ServerHolder(druidServer1, peon1),
-                                                                       new ServerHolder(druidServer2, peon2),
-                                                                       new ServerHolder(druidServer3, peon3),
-                                                                       new ServerHolder(druidServer4, peon4)
-                                                                   )
-                                                               )
-                                        )
-                                    )
+        DruidCoordinatorRuntimeParams
+            .newBuilder()
+            .withDruidCluster(
+                new DruidCluster(
+                    ImmutableMap.<String, MinMaxPriorityQueue<ServerHolder>>of(
+                        "normal",
+                        MinMaxPriorityQueue
+                            .orderedBy(DruidCoordinatorBalancerTester.percentUsedComparator)
+                            .create(
+                                Arrays.asList(
+                                    new ServerHolder(druidServer1, peon1),
+                                    new ServerHolder(druidServer2, peon2),
+                                    new ServerHolder(druidServer3, peon3),
+                                    new ServerHolder(druidServer4, peon4)
                                 )
-                                .withLoadManagementPeons(
-                                    ImmutableMap.<String, LoadQueuePeon>of(
-                                        "1",
-                                        peon1,
-                                        "2",
-                                        peon2,
-                                        "3",
-                                        peon3,
-                                        "4",
-                                        peon4
-                                    )
-                                )
-                                .withAvailableSegments(segments.values())
-                                .withDynamicConfigs(
-                                    new CoordinatorDynamicConfig.Builder().withMaxSegmentsToMove(
-                                        MAX_SEGMENTS_TO_MOVE
-                                    ).build()
-                                )
-                                     .withBalancerStrategy(balancerStrategy)
-                                     .withBalancerReferenceTimestamp(new DateTime("2013-01-01"))
-                                .build();
+                            )
+                    )
+                )
+            )
+            .withLoadManagementPeons(
+                ImmutableMap.<String, LoadQueuePeon>of(
+                    "1", peon1,
+                    "2", peon2,
+                    "3", peon3,
+                    "4", peon4
+                )
+            )
+            .withAvailableSegments(segments.values())
+            .withDynamicConfigs(
+                new CoordinatorDynamicConfig.Builder().withMaxSegmentsToMove(
+                    MAX_SEGMENTS_TO_MOVE
+                ).build()
+            )
+            .withBalancerStrategy(balancerStrategy)
+            .withBalancerReferenceTimestamp(new DateTime("2013-01-01"))
+            .build();
 
     params = new DruidCoordinatorBalancerTester(coordinator).run(params);
     Assert.assertTrue(params.getCoordinatorStats().getPerTierStats().get("movedCount").get("normal").get() > 0);
@@ -404,47 +333,10 @@ public class DruidCoordinatorBalancerTest
   public void testMaxSegmentsToMovePerTier() throws IOException
   {
     // Mock some servers of different usages
-    EasyMock.expect(druidServer1.getName()).andReturn("1").atLeastOnce();
-    EasyMock.expect(druidServer1.getTier()).andReturn("normal").anyTimes();
-    EasyMock.expect(druidServer1.getCurrSize()).andReturn(30L).atLeastOnce();
-    EasyMock.expect(druidServer1.getMaxSize()).andReturn(100L).atLeastOnce();
-    EasyMock.expect(druidServer1.getSegments()).andReturn(segments).anyTimes();
-    EasyMock.expect(druidServer1.getSegment(EasyMock.<String>anyObject())).andReturn(null).anyTimes();
-    EasyMock.replay(druidServer1);
-
-    EasyMock.expect(druidServer2.getName()).andReturn("2").atLeastOnce();
-    EasyMock.expect(druidServer2.getTier()).andReturn("normal").anyTimes();
-    EasyMock.expect(druidServer2.getCurrSize()).andReturn(0L).atLeastOnce();
-    EasyMock.expect(druidServer2.getMaxSize()).andReturn(100L).atLeastOnce();
-    EasyMock.expect(druidServer2.getSegments()).andReturn(new HashMap<String, DataSegment>()).anyTimes();
-    EasyMock.expect(druidServer2.getSegment(EasyMock.<String>anyObject())).andReturn(null).anyTimes();
-    EasyMock.replay(druidServer2);
-
-    EasyMock.expect(druidServer3.getName()).andReturn("3").atLeastOnce();
-    EasyMock.expect(druidServer3.getTier()).andReturn("extra").anyTimes();
-    EasyMock.expect(druidServer3.getCurrSize()).andReturn(0L).atLeastOnce();
-    EasyMock.expect(druidServer3.getMaxSize()).andReturn(100L).atLeastOnce();
-    EasyMock.expect(druidServer3.getSegments()).andReturn(segments).anyTimes();
-    EasyMock.expect(druidServer3.getSegment(EasyMock.<String>anyObject())).andReturn(null).anyTimes();
-    EasyMock.replay(druidServer3);
-
-    EasyMock.expect(druidServer4.getName()).andReturn("4").atLeastOnce();
-    EasyMock.expect(druidServer4.getTier()).andReturn("extra").anyTimes();
-    EasyMock.expect(druidServer4.getCurrSize()).andReturn(0L).atLeastOnce();
-    EasyMock.expect(druidServer4.getMaxSize()).andReturn(100L).atLeastOnce();
-    EasyMock.expect(druidServer4.getSegments()).andReturn(new HashMap<String, DataSegment>()).anyTimes();
-    EasyMock.expect(druidServer4.getSegment(EasyMock.<String>anyObject())).andReturn(null).anyTimes();
-    EasyMock.replay(druidServer4);
-
-    // Mock stuff that the coordinator needs
-    coordinator.moveSegment(
-        EasyMock.<ImmutableDruidServer>anyObject(),
-        EasyMock.<ImmutableDruidServer>anyObject(),
-        EasyMock.<String>anyObject(),
-        EasyMock.<LoadPeonCallback>anyObject()
-    );
-    EasyMock.expectLastCall().anyTimes();
-    EasyMock.replay(coordinator);
+    mockDruidServer(druidServer1, "1", "normal", 30L, 100L, segments);
+    mockDruidServer(druidServer2, "2", "normal", 0L, 100L, new HashMap<>());
+    mockDruidServer(druidServer3, "3", "extra", 30L, 100L, segments);
+    mockDruidServer(druidServer4, "4", "extra", 0L, 100L, new HashMap<>());
 
     LoadQueuePeonTester peon1 = new LoadQueuePeonTester();
     LoadQueuePeonTester peon2 = new LoadQueuePeonTester();
@@ -452,53 +344,52 @@ public class DruidCoordinatorBalancerTest
     LoadQueuePeonTester peon4 = new LoadQueuePeonTester();
 
     ListeningExecutorService exec = MoreExecutors.listeningDecorator(
-        Executors.newFixedThreadPool(1));
+        Execs.singleThreaded("balancer-strategy-exec"));
 
     BalancerStrategy balancerStrategy = createBalancerStrategy(exec);
 
     Map<String, MinMaxPriorityQueue<ServerHolder>> cluster = new HashMap<>();
-    cluster.put("normal", MinMaxPriorityQueue.orderedBy(DruidCoordinatorBalancerTester.percentUsedComparator)
-                                             .create(
-                                                 Arrays.asList(
-                                                     new ServerHolder(druidServer1, peon1),
-                                                     new ServerHolder(druidServer2, peon2)
-                                                 )
-                                             ));
+    cluster.put("normal", MinMaxPriorityQueue
+        .orderedBy(DruidCoordinatorBalancerTester.percentUsedComparator)
+        .create(
+            Arrays.asList(
+                new ServerHolder(druidServer1, peon1),
+                new ServerHolder(druidServer2, peon2)
+            )
+        ));
 
-    cluster.put("extra", MinMaxPriorityQueue.orderedBy(DruidCoordinatorBalancerTester.percentUsedComparator)
-                                            .create(
-                                               Arrays.asList(
-                                                   new ServerHolder(druidServer3, peon3),
-                                                   new ServerHolder(druidServer4, peon4)
-                                               )
-                                            ));
+    cluster.put("extra", MinMaxPriorityQueue
+        .orderedBy(DruidCoordinatorBalancerTester.percentUsedComparator)
+        .create(
+            Arrays.asList(
+                new ServerHolder(druidServer3, peon3),
+                new ServerHolder(druidServer4, peon4)
+            )
+        ));
 
     DruidCoordinatorRuntimeParams params =
-        DruidCoordinatorRuntimeParams.newBuilder()
-                                     .withDruidCluster(
-                                         new DruidCluster(cluster)
-                                     )
-                                     .withLoadManagementPeons(
-                                         ImmutableMap.<String, LoadQueuePeon>of(
-                                             "1",
-                                             peon1,
-                                             "2",
-                                             peon2,
-                                             "3",
-                                             peon3,
-                                             "4",
-                                             peon4
-                                         )
-                                     )
-                                     .withAvailableSegments(segments.values())
-                                     .withDynamicConfigs(
-                                         new CoordinatorDynamicConfig.Builder().withMaxSegmentsToMove(
-                                             1
-                                         ).build()
-                                     )
-                                     .withBalancerStrategy(balancerStrategy)
-                                     .withBalancerReferenceTimestamp(new DateTime("2013-01-01"))
-                                     .build();
+        DruidCoordinatorRuntimeParams
+            .newBuilder()
+            .withDruidCluster(
+                new DruidCluster(cluster)
+            )
+            .withLoadManagementPeons(
+                ImmutableMap.<String, LoadQueuePeon>of(
+                    "1", peon1,
+                    "2", peon2,
+                    "3", peon3,
+                    "4", peon4
+                )
+            )
+            .withAvailableSegments(segments.values())
+            .withDynamicConfigs(
+                new CoordinatorDynamicConfig.Builder().withMaxSegmentsToMove(
+                    1
+                ).build()
+            )
+            .withBalancerStrategy(balancerStrategy)
+            .withBalancerReferenceTimestamp(new DateTime("2013-01-01"))
+            .build();
 
     DruidCoordinatorBalancerTester balancerTester = new DruidCoordinatorBalancerTester(coordinator);
     params = balancerTester.run(params);
@@ -512,47 +403,10 @@ public class DruidCoordinatorBalancerTest
   public void testMaxSegmentsToMove() throws IOException
   {
     // Mock some servers of different usages
-    EasyMock.expect(druidServer1.getName()).andReturn("1").atLeastOnce();
-    EasyMock.expect(druidServer1.getTier()).andReturn("normal").anyTimes();
-    EasyMock.expect(druidServer1.getCurrSize()).andReturn(30L).atLeastOnce();
-    EasyMock.expect(druidServer1.getMaxSize()).andReturn(100L).atLeastOnce();
-    EasyMock.expect(druidServer1.getSegments()).andReturn(segments).anyTimes();
-    EasyMock.expect(druidServer1.getSegment(EasyMock.<String>anyObject())).andReturn(null).anyTimes();
-    EasyMock.replay(druidServer1);
-
-    EasyMock.expect(druidServer2.getName()).andReturn("2").atLeastOnce();
-    EasyMock.expect(druidServer2.getTier()).andReturn("normal").anyTimes();
-    EasyMock.expect(druidServer2.getCurrSize()).andReturn(0L).atLeastOnce();
-    EasyMock.expect(druidServer2.getMaxSize()).andReturn(100L).atLeastOnce();
-    EasyMock.expect(druidServer2.getSegments()).andReturn(new HashMap<String, DataSegment>()).anyTimes();
-    EasyMock.expect(druidServer2.getSegment(EasyMock.<String>anyObject())).andReturn(null).anyTimes();
-    EasyMock.replay(druidServer2);
-
-    EasyMock.expect(druidServer3.getName()).andReturn("3").atLeastOnce();
-    EasyMock.expect(druidServer3.getTier()).andReturn("normal").anyTimes();
-    EasyMock.expect(druidServer3.getCurrSize()).andReturn(0L).atLeastOnce();
-    EasyMock.expect(druidServer3.getMaxSize()).andReturn(100L).atLeastOnce();
-    EasyMock.expect(druidServer3.getSegments()).andReturn(segments).anyTimes();
-    EasyMock.expect(druidServer3.getSegment(EasyMock.<String>anyObject())).andReturn(null).anyTimes();
-    EasyMock.replay(druidServer3);
-
-    EasyMock.expect(druidServer4.getName()).andReturn("4").atLeastOnce();
-    EasyMock.expect(druidServer4.getTier()).andReturn("normal").anyTimes();
-    EasyMock.expect(druidServer4.getCurrSize()).andReturn(0L).atLeastOnce();
-    EasyMock.expect(druidServer4.getMaxSize()).andReturn(100L).atLeastOnce();
-    EasyMock.expect(druidServer4.getSegments()).andReturn(new HashMap<String, DataSegment>()).anyTimes();
-    EasyMock.expect(druidServer4.getSegment(EasyMock.<String>anyObject())).andReturn(null).anyTimes();
-    EasyMock.replay(druidServer4);
-
-    // Mock stuff that the coordinator needs
-    coordinator.moveSegment(
-        EasyMock.<ImmutableDruidServer>anyObject(),
-        EasyMock.<ImmutableDruidServer>anyObject(),
-        EasyMock.<String>anyObject(),
-        EasyMock.<LoadPeonCallback>anyObject()
-    );
-    EasyMock.expectLastCall().anyTimes();
-    EasyMock.replay(coordinator);
+    mockDruidServer(druidServer1, "1", "normal", 30L, 100L, segments);
+    mockDruidServer(druidServer2, "2", "normal", 0L, 100L, new HashMap<>());
+    mockDruidServer(druidServer3, "3", "normal", 0L, 100L, new HashMap<>());
+    mockDruidServer(druidServer4, "4", "normal", 0L, 100L, new HashMap<>());
 
     LoadQueuePeonTester peon1 = new LoadQueuePeonTester();
     LoadQueuePeonTester peon2 = new LoadQueuePeonTester();
@@ -560,45 +414,43 @@ public class DruidCoordinatorBalancerTest
     LoadQueuePeonTester peon4 = new LoadQueuePeonTester();
 
     ListeningExecutorService exec = MoreExecutors.listeningDecorator(
-        Executors.newFixedThreadPool(1));
+        Execs.singleThreaded("balancer-strategy-exec"));
     BalancerStrategy balancerStrategy = createBalancerStrategy(exec);
 
     Map<String, MinMaxPriorityQueue<ServerHolder>> cluster = new HashMap<>();
-    cluster.put("normal", MinMaxPriorityQueue.orderedBy(DruidCoordinatorBalancerTester.percentUsedComparator)
-                                             .create(
-                                                 Arrays.asList(
-                                                     new ServerHolder(druidServer1, peon1),
-                                                     new ServerHolder(druidServer2, peon2),
-                                                     new ServerHolder(druidServer3, peon3),
-                                                     new ServerHolder(druidServer4, peon4)
-                                                 )
-                                             ));
+    cluster.put("normal", MinMaxPriorityQueue
+        .orderedBy(DruidCoordinatorBalancerTester.percentUsedComparator)
+        .create(
+            Arrays.asList(
+                new ServerHolder(druidServer1, peon1),
+                new ServerHolder(druidServer2, peon2),
+                new ServerHolder(druidServer3, peon3),
+                new ServerHolder(druidServer4, peon4)
+            )
+        ));
     DruidCoordinatorRuntimeParams params =
-        DruidCoordinatorRuntimeParams.newBuilder()
-                                     .withDruidCluster(
-                                         new DruidCluster(cluster)
-                                     )
-                                     .withLoadManagementPeons(
-                                         ImmutableMap.<String, LoadQueuePeon>of(
-                                             "1",
-                                             peon1,
-                                             "2",
-                                             peon2,
-                                             "3",
-                                             peon3,
-                                             "4",
-                                             peon4
-                                         )
-                                     )
-                                     .withAvailableSegments(segments.values())
-                                     .withDynamicConfigs(
-                                         new CoordinatorDynamicConfig.Builder().withMaxSegmentsToMove(
-                                             1
-                                         ).build()
-                                     )
-                                     .withBalancerStrategy(balancerStrategy)
-                                     .withBalancerReferenceTimestamp(new DateTime("2013-01-01"))
-                                     .build();
+        DruidCoordinatorRuntimeParams
+            .newBuilder()
+            .withDruidCluster(
+                new DruidCluster(cluster)
+            )
+            .withLoadManagementPeons(
+                ImmutableMap.<String, LoadQueuePeon>of(
+                    "1", peon1,
+                    "2", peon2,
+                    "3", peon3,
+                    "4", peon4
+                )
+            )
+            .withAvailableSegments(segments.values())
+            .withDynamicConfigs(
+                new CoordinatorDynamicConfig.Builder().withMaxSegmentsToMove(
+                    1
+                ).build()
+            )
+            .withBalancerStrategy(balancerStrategy)
+            .withBalancerReferenceTimestamp(new DateTime("2013-01-01"))
+            .build();
 
     DruidCoordinatorBalancerTester balancerTester = new DruidCoordinatorBalancerTester(coordinator);
     params = balancerTester.run(params);
@@ -617,7 +469,26 @@ public class DruidCoordinatorBalancerTest
     exec.shutdown();
   }
 
-  private BalancerStrategy createBalancerStrategy(ListeningExecutorService exec) {
+  private void mockDruidServer(
+      ImmutableDruidServer druidServer,
+      String name,
+      String tier,
+      long currSize,
+      long maxSize,
+      Map<String, DataSegment> segments
+  )
+  {
+    EasyMock.expect(druidServer.getName()).andReturn(name).atLeastOnce();
+    EasyMock.expect(druidServer.getTier()).andReturn(tier).anyTimes();
+    EasyMock.expect(druidServer.getCurrSize()).andReturn(currSize).atLeastOnce();
+    EasyMock.expect(druidServer.getMaxSize()).andReturn(maxSize).atLeastOnce();
+    EasyMock.expect(druidServer.getSegments()).andReturn(segments).anyTimes();
+    EasyMock.expect(druidServer.getSegment(EasyMock.<String>anyObject())).andReturn(null).anyTimes();
+    EasyMock.replay(druidServer);
+  }
+
+  private BalancerStrategy createBalancerStrategy(ListeningExecutorService exec)
+  {
     final BalancerStrategy costBalancerStrategy =
         new CostBalancerStrategyFactory().createBalancerStrategy(exec);
 

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerTester.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerTester.java
@@ -31,7 +31,7 @@ public class DruidCoordinatorBalancerTester extends DruidCoordinatorBalancer
   }
 
   @Override
-  protected void moveSegment(
+  protected boolean moveSegment(
       final BalancerSegmentHolder segment,
       final ImmutableDruidServer toServer,
       final DruidCoordinatorRuntimeParams params
@@ -66,6 +66,7 @@ public class DruidCoordinatorBalancerTester extends DruidCoordinatorBalancer
         });
 
         currentlyMovingSegments.get("normal").put(segmentName, segment);
+        return true;
       }
       catch (Exception e) {
         log.info(e, String.format("[%s] : Moving exception", segmentName));
@@ -73,5 +74,6 @@ public class DruidCoordinatorBalancerTester extends DruidCoordinatorBalancer
     } else {
       currentlyMovingSegments.get("normal").remove(segment);
     }
+    return false;
   }
 }

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerTester.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerTester.java
@@ -45,7 +45,7 @@ public class DruidCoordinatorBalancerTester extends DruidCoordinatorBalancer
     final String segmentName = segmentToMove.getIdentifier();
 
     if (!toPeon.getSegmentsToLoad().contains(segmentToMove) &&
-        !currentlyMovingSegments.get("normal").containsKey(segmentName) &&
+        !currentlyMovingSegments.get(toServer.getTier()).containsKey(segmentName) &&
         !toServer.getSegments().containsKey(segmentName) &&
         new ServerHolder(toServer, toPeon).getAvailableSize() > segmentToMove.getSize()) {
       log.info(
@@ -65,14 +65,14 @@ public class DruidCoordinatorBalancerTester extends DruidCoordinatorBalancer
           }
         });
 
-        currentlyMovingSegments.get("normal").put(segmentName, segment);
+        currentlyMovingSegments.get(toServer.getTier()).put(segmentName, segment);
         return true;
       }
       catch (Exception e) {
         log.info(e, String.format("[%s] : Moving exception", segmentName));
       }
     } else {
-      currentlyMovingSegments.get("normal").remove(segment);
+      currentlyMovingSegments.get(toServer.getTier()).remove(segment);
     }
     return false;
   }


### PR DESCRIPTION
Changes in DruidCoordinatorBalancer:

1) Do not wait until all segments are moved before moving new segments. In previous version one stuck segment could stop the whole tier rebalancing.

2) As per documentation http://druid.io/docs/latest/configuration/coordinator.html maxSegmentsToMove is the "maximum number of segments that can be moved at any given time" while right now it's possible to have numberOfTiers * maxSegmentsToMove segments to be moving at the same time. It looks reasonable to have this configuration on tier level because instead the first tier (in sense of hash map iterator order) will utilize the whole capacity and prevent other tiers to be rebalanced.

3) Fixes incorrect logging for number of segments that are still moving (right now number of tiers is logged instead of number of segments)