### PR TITLE
[BACKEND-469] Option to configure default analysis types for Segment Metadata Query

### DIFF
--- a/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryConfig.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryConfig.java
@@ -25,24 +25,23 @@ import org.joda.time.Period;
 import org.joda.time.format.ISOPeriodFormat;
 import org.joda.time.format.PeriodFormatter;
 
-import javax.annotation.Nullable;
 import java.util.EnumSet;
 
 public class SegmentMetadataQueryConfig
 {
   private static final String DEFAULT_PERIOD_STRING = "P1W";
   private static final PeriodFormatter ISO_FORMATTER = ISOPeriodFormat.standard();
+  static final EnumSet<SegmentMetadataQuery.AnalysisType> DEFAULT_ANALYSIS_TYPES = EnumSet.of(
+      SegmentMetadataQuery.AnalysisType.CARDINALITY,
+      SegmentMetadataQuery.AnalysisType.INTERVAL,
+      SegmentMetadataQuery.AnalysisType.MINMAX
+  );
 
   @JsonProperty
   private Period defaultHistory = ISO_FORMATTER.parsePeriod(DEFAULT_PERIOD_STRING);
 
   @JsonProperty
-  private EnumSet<SegmentMetadataQuery.AnalysisType> defaultAnalysisType = null;
-
-  public SegmentMetadataQueryConfig(EnumSet<SegmentMetadataQuery.AnalysisType> analysisType)
-  {
-    defaultAnalysisType = analysisType;
-  }
+  private EnumSet<SegmentMetadataQuery.AnalysisType> defaultAnalysisType = DEFAULT_ANALYSIS_TYPES;
 
   public SegmentMetadataQueryConfig(String period)
   {
@@ -58,6 +57,15 @@ public class SegmentMetadataQueryConfig
     return defaultHistory;
   }
 
-  @Nullable
+  public void setDefaultHistory(String period)
+  {
+    this.defaultHistory = ISO_FORMATTER.parsePeriod(period);
+  }
+
   public EnumSet<SegmentMetadataQuery.AnalysisType> getDefaultAnalysisType() { return defaultAnalysisType; }
+
+  public void setDefaultAnalysisType(EnumSet<SegmentMetadataQuery.AnalysisType> defaultAnalysisType)
+  {
+    this.defaultAnalysisType = defaultAnalysisType;
+  }
 }

--- a/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryConfig.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryConfig.java
@@ -20,10 +20,12 @@
 package io.druid.query.metadata;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.druid.query.metadata.metadata.SegmentMetadataQuery;
 import org.joda.time.Period;
 import org.joda.time.format.ISOPeriodFormat;
 import org.joda.time.format.PeriodFormatter;
 
+import java.util.EnumSet;
 
 public class SegmentMetadataQueryConfig
 {
@@ -33,8 +35,23 @@ public class SegmentMetadataQueryConfig
   @JsonProperty
   private Period defaultHistory = ISO_FORMATTER.parsePeriod(DEFAULT_PERIOD_STRING);
 
+  @JsonProperty
+  private EnumSet<SegmentMetadataQuery.AnalysisType> defaultAnalysisType = SegmentMetadataQuery.DEFAULT_ANALYSIS_TYPES;
+
+  public SegmentMetadataQueryConfig(String period, EnumSet<SegmentMetadataQuery.AnalysisType> analysisType)
+  {
+    defaultHistory = ISO_FORMATTER.parsePeriod(period);
+    defaultAnalysisType = analysisType;
+  }
+
+  public SegmentMetadataQueryConfig(EnumSet<SegmentMetadataQuery.AnalysisType> analysisType)
+  {
+    defaultAnalysisType = analysisType;
+  }
+
   public SegmentMetadataQueryConfig(String period)
   {
+
     defaultHistory = ISO_FORMATTER.parsePeriod(period);
   }
 
@@ -46,4 +63,6 @@ public class SegmentMetadataQueryConfig
   {
     return defaultHistory;
   }
+
+  public EnumSet<SegmentMetadataQuery.AnalysisType> getDefaultAnalysisType() { return defaultAnalysisType; }
 }

--- a/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryConfig.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryConfig.java
@@ -46,7 +46,6 @@ public class SegmentMetadataQueryConfig
 
   public SegmentMetadataQueryConfig(String period)
   {
-
     defaultHistory = ISO_FORMATTER.parsePeriod(period);
   }
 

--- a/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryConfig.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryConfig.java
@@ -25,6 +25,7 @@ import org.joda.time.Period;
 import org.joda.time.format.ISOPeriodFormat;
 import org.joda.time.format.PeriodFormatter;
 
+import javax.annotation.Nullable;
 import java.util.EnumSet;
 
 public class SegmentMetadataQueryConfig
@@ -36,13 +37,7 @@ public class SegmentMetadataQueryConfig
   private Period defaultHistory = ISO_FORMATTER.parsePeriod(DEFAULT_PERIOD_STRING);
 
   @JsonProperty
-  private EnumSet<SegmentMetadataQuery.AnalysisType> defaultAnalysisType = SegmentMetadataQuery.DEFAULT_ANALYSIS_TYPES;
-
-  public SegmentMetadataQueryConfig(String period, EnumSet<SegmentMetadataQuery.AnalysisType> analysisType)
-  {
-    defaultHistory = ISO_FORMATTER.parsePeriod(period);
-    defaultAnalysisType = analysisType;
-  }
+  private EnumSet<SegmentMetadataQuery.AnalysisType> defaultAnalysisType = null;
 
   public SegmentMetadataQueryConfig(EnumSet<SegmentMetadataQuery.AnalysisType> analysisType)
   {
@@ -64,5 +59,6 @@ public class SegmentMetadataQueryConfig
     return defaultHistory;
   }
 
+  @Nullable
   public EnumSet<SegmentMetadataQuery.AnalysisType> getDefaultAnalysisType() { return defaultAnalysisType; }
 }

--- a/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
@@ -403,7 +403,6 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
     } else {
       return query.getAnalysisTypes();
     }
-
   }
 
   public SegmentAnalyzer getSegmentAnalyzer(SegmentMetadataQuery query)

--- a/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
@@ -58,6 +58,7 @@ import org.joda.time.Interval;
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -175,7 +176,7 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
       public byte[] computeCacheKey(SegmentMetadataQuery query)
       {
         byte[] includerBytes = query.getToInclude().getCacheKey();
-        byte[] analysisTypesBytes = query.getAnalysisTypesCacheKey();
+        byte[] analysisTypesBytes = getAnalysisTypesCacheKey(query);
         return ByteBuffer.allocate(1 + includerBytes.length + analysisTypesBytes.length)
                          .put(SEGMENT_METADATA_CACHE_PREFIX)
                          .put(includerBytes)
@@ -390,5 +391,40 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
         analysis.getQueryGranularity(),
         analysis.isRollup()
     );
+  }
+
+  public EnumSet<SegmentMetadataQuery.AnalysisType> getAnalysisTypes(SegmentMetadataQuery query)
+  {
+    if(query.getAnalysisTypes().hashCode() == SegmentMetadataQuery.DEFAULT_ANALYSIS_TYPES.hashCode() && config != null) {
+      return config.getDefaultAnalysisType();
+    }
+    return query.getAnalysisTypes();
+  }
+
+  public SegmentAnalyzer getSegmentAnalyzer(SegmentMetadataQuery query)
+  {
+    EnumSet<SegmentMetadataQuery.AnalysisType> analysisTypes = getAnalysisTypes(query);
+    return new SegmentAnalyzer(analysisTypes);
+  }
+
+  private byte[] getAnalysisTypesCacheKey(SegmentMetadataQuery query)
+  {
+    int size = 1;
+    EnumSet<SegmentMetadataQuery.AnalysisType> analysisTypes = getAnalysisTypes(query);
+
+    List<byte[]> typeBytesList = Lists.newArrayListWithExpectedSize(analysisTypes.size());
+    for (SegmentMetadataQuery.AnalysisType analysisType : analysisTypes) {
+      final byte[] bytes = analysisType.getCacheKey();
+      typeBytesList.add(bytes);
+      size += bytes.length;
+    }
+
+    final ByteBuffer bytes = ByteBuffer.allocate(size);
+    bytes.put(SegmentMetadataQuery.ANALYSIS_TYPES_CACHE_PREFIX);
+    for (byte[] typeBytes : typeBytesList) {
+      bytes.put(typeBytes);
+    }
+
+    return bytes.array();
   }
 }

--- a/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
@@ -396,10 +396,7 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
   public EnumSet<SegmentMetadataQuery.AnalysisType> getAnalysisTypes(SegmentMetadataQuery query)
   {
     if (query.getAnalysisTypes() == null) {
-      if (config == null || config.getDefaultAnalysisType() == null) {
-        return SegmentMetadataQuery.DEFAULT_ANALYSIS_TYPES;
-      }
-      return config.getDefaultAnalysisType();
+      return config != null ? config.getDefaultAnalysisType() : SegmentMetadataQueryConfig.DEFAULT_ANALYSIS_TYPES;
     } else {
       return query.getAnalysisTypes();
     }

--- a/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryQueryToolChest.java
@@ -395,24 +395,28 @@ public class SegmentMetadataQueryQueryToolChest extends QueryToolChest<SegmentAn
 
   public EnumSet<SegmentMetadataQuery.AnalysisType> getAnalysisTypes(SegmentMetadataQuery query)
   {
-    if(query.getAnalysisTypes().hashCode() == SegmentMetadataQuery.DEFAULT_ANALYSIS_TYPES.hashCode() && config != null) {
+    if (query.getAnalysisTypes() == null) {
+      if (config == null || config.getDefaultAnalysisType() == null) {
+        return SegmentMetadataQuery.DEFAULT_ANALYSIS_TYPES;
+      }
       return config.getDefaultAnalysisType();
+    } else {
+      return query.getAnalysisTypes();
     }
-    return query.getAnalysisTypes();
+
   }
 
   public SegmentAnalyzer getSegmentAnalyzer(SegmentMetadataQuery query)
   {
-    EnumSet<SegmentMetadataQuery.AnalysisType> analysisTypes = getAnalysisTypes(query);
-    return new SegmentAnalyzer(analysisTypes);
+    return new SegmentAnalyzer(getAnalysisTypes(query));
   }
 
   private byte[] getAnalysisTypesCacheKey(SegmentMetadataQuery query)
   {
     int size = 1;
-    EnumSet<SegmentMetadataQuery.AnalysisType> analysisTypes = getAnalysisTypes(query);
+    final EnumSet<SegmentMetadataQuery.AnalysisType> analysisTypes = getAnalysisTypes(query);
 
-    List<byte[]> typeBytesList = Lists.newArrayListWithExpectedSize(analysisTypes.size());
+    final List<byte[]> typeBytesList = Lists.newArrayListWithExpectedSize(analysisTypes.size());
     for (SegmentMetadataQuery.AnalysisType analysisType : analysisTypes) {
       final byte[] bytes = analysisType.getCacheKey();
       typeBytesList.add(bytes);

--- a/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryRunnerFactory.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryRunnerFactory.java
@@ -53,6 +53,7 @@ import org.joda.time.Interval;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -113,7 +114,12 @@ public class SegmentMetadataQueryRunnerFactory implements QueryRunnerFactory<Seg
             columns.put(columnName, column);
           }
         }
-        List<Interval> retIntervals = analysisTypes.contains(AnalysisType.INTERVAL) ? Arrays.asList(segment.getDataInterval()) : null;
+        List<Interval> retIntervals;
+        if (analysisTypes.contains(AnalysisType.INTERVAL)) {
+          retIntervals = Collections.singletonList(segment.getDataInterval());
+        } else {
+          retIntervals = null;
+        }
 
         final Map<String, AggregatorFactory> aggregators;
         Metadata metadata = null;

--- a/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryRunnerFactory.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryRunnerFactory.java
@@ -87,7 +87,7 @@ public class SegmentMetadataQueryRunnerFactory implements QueryRunnerFactory<Seg
       public Sequence<SegmentAnalysis> run(Query<SegmentAnalysis> inQ, Map<String, Object> responseContext)
       {
         SegmentMetadataQuery query = (SegmentMetadataQuery) inQ;
-        final SegmentAnalyzer analyzer = new SegmentAnalyzer(query.getAnalysisTypes());
+        final SegmentAnalyzer analyzer = toolChest.getSegmentAnalyzer(query);
         final Map<String, ColumnAnalysis> analyzedColumns = analyzer.analyze(segment);
         final long numRows = analyzer.numRows(segment);
         long totalSize = 0;

--- a/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryRunnerFactory.java
+++ b/processing/src/main/java/io/druid/query/metadata/SegmentMetadataQueryRunnerFactory.java
@@ -113,7 +113,7 @@ public class SegmentMetadataQueryRunnerFactory implements QueryRunnerFactory<Seg
             columns.put(columnName, column);
           }
         }
-        List<Interval> retIntervals = query.analyzingInterval() ? Arrays.asList(segment.getDataInterval()) : null;
+        List<Interval> retIntervals = analysisTypes.contains(AnalysisType.INTERVAL) ? Arrays.asList(segment.getDataInterval()) : null;
 
         final Map<String, AggregatorFactory> aggregators;
         Metadata metadata = null;

--- a/processing/src/main/java/io/druid/query/metadata/metadata/SegmentMetadataQuery.java
+++ b/processing/src/main/java/io/druid/query/metadata/metadata/SegmentMetadataQuery.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import io.druid.common.utils.JodaUtils;
 import io.druid.query.BaseQuery;
 import io.druid.query.DataSource;
@@ -35,10 +34,8 @@ import io.druid.query.spec.MultipleIntervalSegmentSpec;
 import io.druid.query.spec.QuerySegmentSpec;
 import org.joda.time.Interval;
 
-import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.EnumSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -208,26 +205,6 @@ public class SegmentMetadataQuery extends BaseQuery<SegmentAnalysis>
   {
     return analysisTypes.contains(AnalysisType.MINMAX);
   }
-
-  public byte[] getAnalysisTypesCacheKey()
-  {
-    int size = 1;
-    List<byte[]> typeBytesList = Lists.newArrayListWithExpectedSize(analysisTypes.size());
-    for (AnalysisType analysisType : analysisTypes) {
-      final byte[] bytes = analysisType.getCacheKey();
-      typeBytesList.add(bytes);
-      size += bytes.length;
-    }
-
-    final ByteBuffer bytes = ByteBuffer.allocate(size);
-    bytes.put(ANALYSIS_TYPES_CACHE_PREFIX);
-    for (byte[] typeBytes : typeBytesList) {
-      bytes.put(typeBytes);
-    }
-
-    return bytes.array();
-  }
-
 
   @Override
   public Query<SegmentAnalysis> withOverriddenContext(Map<String, Object> contextOverride)

--- a/processing/src/main/java/io/druid/query/metadata/metadata/SegmentMetadataQuery.java
+++ b/processing/src/main/java/io/druid/query/metadata/metadata/SegmentMetadataQuery.java
@@ -120,7 +120,7 @@ public class SegmentMetadataQuery extends BaseQuery<SegmentAnalysis>
     }
     this.toInclude = toInclude == null ? new AllColumnIncluderator() : toInclude;
     this.merge = merge == null ? false : merge;
-    this.analysisTypes = (analysisTypes == null) ? DEFAULT_ANALYSIS_TYPES : analysisTypes;
+    this.analysisTypes = analysisTypes;
     Preconditions.checkArgument(
         dataSource instanceof TableDataSource || dataSource instanceof UnionDataSource,
         "SegmentMetadataQuery only supports table or union datasource"

--- a/processing/src/main/java/io/druid/query/metadata/metadata/SegmentMetadataQuery.java
+++ b/processing/src/main/java/io/druid/query/metadata/metadata/SegmentMetadataQuery.java
@@ -81,12 +81,6 @@ public class SegmentMetadataQuery extends BaseQuery<SegmentAnalysis>
       JodaUtils.MIN_INSTANT, JodaUtils.MAX_INSTANT
   );
 
-  public static final EnumSet<AnalysisType> DEFAULT_ANALYSIS_TYPES = EnumSet.of(
-      AnalysisType.CARDINALITY,
-      AnalysisType.INTERVAL,
-      AnalysisType.MINMAX
-  );
-
   private final ColumnIncluderator toInclude;
   private final boolean merge;
   private final boolean usingDefaultInterval;

--- a/processing/src/main/java/io/druid/query/metadata/metadata/SegmentMetadataQuery.java
+++ b/processing/src/main/java/io/druid/query/metadata/metadata/SegmentMetadataQuery.java
@@ -176,36 +176,6 @@ public class SegmentMetadataQuery extends BaseQuery<SegmentAnalysis>
     return lenientAggregatorMerge;
   }
 
-  public boolean analyzingInterval()
-  {
-    return analysisTypes.contains(AnalysisType.INTERVAL);
-  }
-
-  public boolean hasAggregators()
-  {
-    return analysisTypes.contains(AnalysisType.AGGREGATORS);
-  }
-
-  public boolean hasTimestampSpec()
-  {
-    return analysisTypes.contains(AnalysisType.TIMESTAMPSPEC);
-  }
-
-  public boolean hasQueryGranularity()
-  {
-    return analysisTypes.contains(AnalysisType.QUERYGRANULARITY);
-  }
-
-  public boolean hasRollup()
-  {
-    return analysisTypes.contains(AnalysisType.ROLLUP);
-  }
-
-  public boolean hasMinMax()
-  {
-    return analysisTypes.contains(AnalysisType.MINMAX);
-  }
-
   @Override
   public Query<SegmentAnalysis> withOverriddenContext(Map<String, Object> contextOverride)
   {

--- a/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
+++ b/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
@@ -820,7 +820,6 @@ public class SegmentMetadataQueryTest
         "failed SegmentMetadata merging query"
     );
     exec.shutdownNow();
-
   }
 
   @Test

--- a/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
+++ b/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
@@ -820,6 +820,7 @@ public class SegmentMetadataQueryTest
         "failed SegmentMetadata merging query"
     );
     exec.shutdownNow();
+
   }
 
   @Test

--- a/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
+++ b/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
@@ -49,6 +49,7 @@ import io.druid.query.metadata.metadata.SegmentMetadataQuery;
 import io.druid.segment.IncrementalIndexSegment;
 import io.druid.segment.QueryableIndex;
 import io.druid.segment.QueryableIndexSegment;
+import io.druid.segment.Segment;
 import io.druid.segment.TestHelper;
 import io.druid.segment.TestIndex;
 import io.druid.segment.column.ValueType;
@@ -1100,4 +1101,40 @@ public class SegmentMetadataQueryTest
 
     Assert.assertFalse(Arrays.equals(oneColumnQueryCacheKey, twoColumnQueryCacheKey));
   }
+
+  @Test
+  public void testAnanlysisTypesBeingSet()
+  {
+
+    SegmentMetadataQuery query1 = Druids.newSegmentMetadataQueryBuilder()
+                                                .dataSource("testing")
+                                                .toInclude(new ListColumnIncluderator(Arrays.asList("foo")))
+                                                .build();
+
+    SegmentMetadataQuery query2 = Druids.newSegmentMetadataQueryBuilder()
+                                        .dataSource("testing")
+                                        .toInclude(new ListColumnIncluderator(Arrays.asList("foo")))
+                                        .analysisTypes(SegmentMetadataQuery.AnalysisType.MINMAX)
+                                        .build();
+
+    SegmentMetadataQueryConfig emptyCfg = new SegmentMetadataQueryConfig();
+    SegmentMetadataQueryConfig analysisCfg = new SegmentMetadataQueryConfig(EnumSet.of(SegmentMetadataQuery.AnalysisType.CARDINALITY));
+
+    EnumSet<SegmentMetadataQuery.AnalysisType> analysis1 = new SegmentMetadataQueryQueryToolChest(emptyCfg).getAnalysisTypes(query1);
+    EnumSet<SegmentMetadataQuery.AnalysisType> analysis2 = new SegmentMetadataQueryQueryToolChest(emptyCfg).getAnalysisTypes(query2);
+    EnumSet<SegmentMetadataQuery.AnalysisType> analysisWCfg1 = new SegmentMetadataQueryQueryToolChest(analysisCfg).getAnalysisTypes(query1);
+    EnumSet<SegmentMetadataQuery.AnalysisType> analysisWCfg2 = new SegmentMetadataQueryQueryToolChest(analysisCfg).getAnalysisTypes(query2);
+
+    EnumSet<SegmentMetadataQuery.AnalysisType> expectedAnalysis1 = SegmentMetadataQuery.DEFAULT_ANALYSIS_TYPES;
+    EnumSet<SegmentMetadataQuery.AnalysisType> expectedAnalysis2 = EnumSet.of(SegmentMetadataQuery.AnalysisType.MINMAX);
+    EnumSet<SegmentMetadataQuery.AnalysisType> expectedAnalysisWCfg1 = EnumSet.of(SegmentMetadataQuery.AnalysisType.CARDINALITY);
+    EnumSet<SegmentMetadataQuery.AnalysisType> expectedAnalysisWCfg2 = EnumSet.of(SegmentMetadataQuery.AnalysisType.MINMAX);
+
+    Assert.assertEquals(analysis1, expectedAnalysis1);
+    Assert.assertEquals(analysis2, expectedAnalysis2);
+    Assert.assertEquals(analysisWCfg1, expectedAnalysisWCfg1);
+    Assert.assertEquals(analysisWCfg2, expectedAnalysisWCfg2);
+
+  }
+
 }

--- a/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
+++ b/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
@@ -49,7 +49,6 @@ import io.druid.query.metadata.metadata.SegmentMetadataQuery;
 import io.druid.segment.IncrementalIndexSegment;
 import io.druid.segment.QueryableIndex;
 import io.druid.segment.QueryableIndexSegment;
-import io.druid.segment.Segment;
 import io.druid.segment.TestHelper;
 import io.druid.segment.TestIndex;
 import io.druid.segment.column.ValueType;

--- a/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
+++ b/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
@@ -1117,14 +1117,15 @@ public class SegmentMetadataQueryTest
                                         .build();
 
     SegmentMetadataQueryConfig emptyCfg = new SegmentMetadataQueryConfig();
-    SegmentMetadataQueryConfig analysisCfg = new SegmentMetadataQueryConfig(EnumSet.of(SegmentMetadataQuery.AnalysisType.CARDINALITY));
+    SegmentMetadataQueryConfig analysisCfg = new SegmentMetadataQueryConfig();
+    analysisCfg.setDefaultAnalysisType(EnumSet.of(SegmentMetadataQuery.AnalysisType.CARDINALITY));
 
     EnumSet<SegmentMetadataQuery.AnalysisType> analysis1 = new SegmentMetadataQueryQueryToolChest(emptyCfg).getAnalysisTypes(query1);
     EnumSet<SegmentMetadataQuery.AnalysisType> analysis2 = new SegmentMetadataQueryQueryToolChest(emptyCfg).getAnalysisTypes(query2);
     EnumSet<SegmentMetadataQuery.AnalysisType> analysisWCfg1 = new SegmentMetadataQueryQueryToolChest(analysisCfg).getAnalysisTypes(query1);
     EnumSet<SegmentMetadataQuery.AnalysisType> analysisWCfg2 = new SegmentMetadataQueryQueryToolChest(analysisCfg).getAnalysisTypes(query2);
 
-    EnumSet<SegmentMetadataQuery.AnalysisType> expectedAnalysis1 = SegmentMetadataQuery.DEFAULT_ANALYSIS_TYPES;
+    EnumSet<SegmentMetadataQuery.AnalysisType> expectedAnalysis1 = SegmentMetadataQueryConfig.DEFAULT_ANALYSIS_TYPES;
     EnumSet<SegmentMetadataQuery.AnalysisType> expectedAnalysis2 = EnumSet.of(SegmentMetadataQuery.AnalysisType.MINMAX);
     EnumSet<SegmentMetadataQuery.AnalysisType> expectedAnalysisWCfg1 = EnumSet.of(SegmentMetadataQuery.AnalysisType.CARDINALITY);
     EnumSet<SegmentMetadataQuery.AnalysisType> expectedAnalysisWCfg2 = EnumSet.of(SegmentMetadataQuery.AnalysisType.MINMAX);

--- a/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
+++ b/processing/src/test/java/io/druid/query/metadata/SegmentMetadataQueryTest.java
@@ -1133,7 +1133,6 @@ public class SegmentMetadataQueryTest
     Assert.assertEquals(analysis2, expectedAnalysis2);
     Assert.assertEquals(analysisWCfg1, expectedAnalysisWCfg1);
     Assert.assertEquals(analysisWCfg2, expectedAnalysisWCfg2);
-
   }
 
 }


### PR DESCRIPTION
https://metamarkets.atlassian.net/browse/BACKEND-469

 - Added `druid.query.segmentMetadata.defaultAnalysisType` which allows the user to configure the default Analysis Type for all Segment Metadata Queries.
 - The value of the config can't be extracted in `SegmentMetadataQuery`'s class without updating the constructor, so I tried to handle analysis in the ToolChest.
 - Ideally I would want to make an update here based on the config value.
```
public static final EnumSet<AnalysisType> DEFAULT_ANALYSIS_TYPES = EnumSet.of(
      AnalysisType.CARDINALITY,
      AnalysisType.INTERVAL,
      AnalysisType.MINMAX
  );
```
, but can't think of a way right now as config is accessible only in the ToolChest.