### PR TITLE
Server selector improvement

### DIFF
--- a/server/src/main/java/io/druid/client/selector/AbstractTierSelectorStrategy.java
+++ b/server/src/main/java/io/druid/client/selector/AbstractTierSelectorStrategy.java
@@ -21,7 +21,6 @@ package io.druid.client.selector;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
-import io.druid.java.util.common.ISE;
 import io.druid.timeline.DataSegment;
 
 import java.util.List;

--- a/server/src/main/java/io/druid/client/selector/AbstractTierSelectorStrategy.java
+++ b/server/src/main/java/io/druid/client/selector/AbstractTierSelectorStrategy.java
@@ -20,13 +20,13 @@
 package io.druid.client.selector;
 
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import io.druid.timeline.DataSegment;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
+import java.util.SortedMap;
 
 /**
  */
@@ -41,7 +41,7 @@ public abstract class AbstractTierSelectorStrategy implements TierSelectorStrate
 
   @Override
   public QueryableDruidServer pick(
-      TreeMap<Integer, Set<QueryableDruidServer>> prioritizedServers, DataSegment segment
+      SortedMap<Integer, Set<QueryableDruidServer>> prioritizedServers, DataSegment segment
   )
   {
     return Iterables.getOnlyElement(pick(prioritizedServers, segment, 1), null);
@@ -49,10 +49,10 @@ public abstract class AbstractTierSelectorStrategy implements TierSelectorStrate
 
   @Override
   public List<QueryableDruidServer> pick(
-      TreeMap<Integer, Set<QueryableDruidServer>> prioritizedServers, DataSegment segment, int numServersToPick
+      SortedMap<Integer, Set<QueryableDruidServer>> prioritizedServers, DataSegment segment, int numServersToPick
   )
   {
-    List<QueryableDruidServer> result = Lists.newArrayList();
+    List<QueryableDruidServer> result = new ArrayList<>();
     for (Map.Entry<Integer, Set<QueryableDruidServer>> priorityServers : prioritizedServers.entrySet()) {
       result.addAll(serverSelectorStrategy.pick(priorityServers.getValue(), segment, numServersToPick - result.size()));
       if (result.size() == numServersToPick) {

--- a/server/src/main/java/io/druid/client/selector/AbstractTierSelectorStrategy.java
+++ b/server/src/main/java/io/druid/client/selector/AbstractTierSelectorStrategy.java
@@ -21,12 +21,12 @@ package io.druid.client.selector;
 
 import com.google.common.collect.Iterables;
 import io.druid.timeline.DataSegment;
+import it.unimi.dsi.fastutil.ints.Int2ObjectRBTreeMap;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.SortedMap;
 
 /**
  */
@@ -41,7 +41,7 @@ public abstract class AbstractTierSelectorStrategy implements TierSelectorStrate
 
   @Override
   public QueryableDruidServer pick(
-      SortedMap<Integer, Set<QueryableDruidServer>> prioritizedServers, DataSegment segment
+      Int2ObjectRBTreeMap<Set<QueryableDruidServer>> prioritizedServers, DataSegment segment
   )
   {
     return Iterables.getOnlyElement(pick(prioritizedServers, segment, 1), null);
@@ -49,7 +49,7 @@ public abstract class AbstractTierSelectorStrategy implements TierSelectorStrate
 
   @Override
   public List<QueryableDruidServer> pick(
-      SortedMap<Integer, Set<QueryableDruidServer>> prioritizedServers, DataSegment segment, int numServersToPick
+      Int2ObjectRBTreeMap<Set<QueryableDruidServer>> prioritizedServers, DataSegment segment, int numServersToPick
   )
   {
     List<QueryableDruidServer> result = new ArrayList<>();

--- a/server/src/main/java/io/druid/client/selector/AbstractTierSelectorStrategy.java
+++ b/server/src/main/java/io/druid/client/selector/AbstractTierSelectorStrategy.java
@@ -25,7 +25,6 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectRBTreeMap;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -41,7 +40,8 @@ public abstract class AbstractTierSelectorStrategy implements TierSelectorStrate
 
   @Override
   public QueryableDruidServer pick(
-      Int2ObjectRBTreeMap<Set<QueryableDruidServer>> prioritizedServers, DataSegment segment
+      Int2ObjectRBTreeMap<Set<QueryableDruidServer>> prioritizedServers,
+      DataSegment segment
   )
   {
     return Iterables.getOnlyElement(pick(prioritizedServers, segment, 1), null);
@@ -49,12 +49,14 @@ public abstract class AbstractTierSelectorStrategy implements TierSelectorStrate
 
   @Override
   public List<QueryableDruidServer> pick(
-      Int2ObjectRBTreeMap<Set<QueryableDruidServer>> prioritizedServers, DataSegment segment, int numServersToPick
+      Int2ObjectRBTreeMap<Set<QueryableDruidServer>> prioritizedServers,
+      DataSegment segment,
+      int numServersToPick
   )
   {
-    List<QueryableDruidServer> result = new ArrayList<>();
-    for (Map.Entry<Integer, Set<QueryableDruidServer>> priorityServers : prioritizedServers.entrySet()) {
-      result.addAll(serverSelectorStrategy.pick(priorityServers.getValue(), segment, numServersToPick - result.size()));
+    List<QueryableDruidServer> result = new ArrayList<>(numServersToPick);
+    for (Set<QueryableDruidServer> priorityServers : prioritizedServers.values()) {
+      result.addAll(serverSelectorStrategy.pick(priorityServers, segment, numServersToPick - result.size()));
       if (result.size() == numServersToPick) {
         break;
       }

--- a/server/src/main/java/io/druid/client/selector/ConnectionCountServerSelectorStrategy.java
+++ b/server/src/main/java/io/druid/client/selector/ConnectionCountServerSelectorStrategy.java
@@ -20,15 +20,13 @@
 package io.druid.client.selector;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
+import com.google.common.collect.Ordering;
 import com.google.common.primitives.Ints;
-import io.druid.java.util.common.guava.Comparators;
 import io.druid.timeline.DataSegment;
 
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.PriorityQueue;
 import java.util.Set;
 
 public class ConnectionCountServerSelectorStrategy implements ServerSelectorStrategy
@@ -54,19 +52,8 @@ public class ConnectionCountServerSelectorStrategy implements ServerSelectorStra
   )
   {
     if (servers.size() <= numServersToPick) {
-      return Lists.newArrayList(servers);
+      return ImmutableList.copyOf(servers);
     }
-    PriorityQueue<QueryableDruidServer> maxHeap = new PriorityQueue<>(numServersToPick, Comparators.inverse(comparator));
-    for (QueryableDruidServer server : servers) {
-      if (maxHeap.size() < numServersToPick) {
-        maxHeap.add(server);
-      } else {
-        if (comparator.compare(server, maxHeap.peek()) < 0) {
-          maxHeap.poll();
-          maxHeap.add(server);
-        }
-      }
-    }
-    return ImmutableList.copyOf(maxHeap);
+    return Ordering.from(comparator).leastOf(servers, numServersToPick);
   }
 }

--- a/server/src/main/java/io/druid/client/selector/ConnectionCountServerSelectorStrategy.java
+++ b/server/src/main/java/io/druid/client/selector/ConnectionCountServerSelectorStrategy.java
@@ -19,6 +19,7 @@
 
 package io.druid.client.selector;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.primitives.Ints;
 import io.druid.java.util.common.guava.Comparators;
@@ -66,6 +67,6 @@ public class ConnectionCountServerSelectorStrategy implements ServerSelectorStra
         }
       }
     }
-    return Lists.newArrayList(maxHeap);
+    return ImmutableList.copyOf(maxHeap);
   }
 }

--- a/server/src/main/java/io/druid/client/selector/RandomServerSelectorStrategy.java
+++ b/server/src/main/java/io/druid/client/selector/RandomServerSelectorStrategy.java
@@ -25,17 +25,15 @@ import io.druid.timeline.DataSegment;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class RandomServerSelectorStrategy implements ServerSelectorStrategy
 {
-  private static final Random random = new Random();
-
   @Override
   public QueryableDruidServer pick(Set<QueryableDruidServer> servers, DataSegment segment)
   {
-    return Iterators.get(servers.iterator(), random.nextInt(servers.size()));
+    return Iterators.get(servers.iterator(), ThreadLocalRandom.current().nextInt(servers.size()));
   }
 
   @Override
@@ -44,7 +42,7 @@ public class RandomServerSelectorStrategy implements ServerSelectorStrategy
   )
   {
     List<QueryableDruidServer> list = Lists.newArrayList(servers);
-    Collections.shuffle(list);
+    Collections.shuffle(list, ThreadLocalRandom.current());
     return list.subList(0, Math.min(list.size(), numServersToPick));
   }
 }

--- a/server/src/main/java/io/druid/client/selector/RandomServerSelectorStrategy.java
+++ b/server/src/main/java/io/druid/client/selector/RandomServerSelectorStrategy.java
@@ -19,6 +19,7 @@
 
 package io.druid.client.selector;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import io.druid.timeline.DataSegment;
@@ -41,8 +42,11 @@ public class RandomServerSelectorStrategy implements ServerSelectorStrategy
       Set<QueryableDruidServer> servers, DataSegment segment, int numServersToPick
   )
   {
+    if (servers.size() <= numServersToPick) {
+      return ImmutableList.copyOf(servers);
+    }
     List<QueryableDruidServer> list = Lists.newArrayList(servers);
     Collections.shuffle(list, ThreadLocalRandom.current());
-    return list.subList(0, Math.min(list.size(), numServersToPick));
+    return ImmutableList.copyOf(list.subList(0, Math.min(list.size(), numServersToPick)));
   }
 }

--- a/server/src/main/java/io/druid/client/selector/RandomServerSelectorStrategy.java
+++ b/server/src/main/java/io/druid/client/selector/RandomServerSelectorStrategy.java
@@ -38,15 +38,13 @@ public class RandomServerSelectorStrategy implements ServerSelectorStrategy
   }
 
   @Override
-  public List<QueryableDruidServer> pick(
-      Set<QueryableDruidServer> servers, DataSegment segment, int numServersToPick
-  )
+  public List<QueryableDruidServer> pick(Set<QueryableDruidServer> servers, DataSegment segment, int numServersToPick)
   {
     if (servers.size() <= numServersToPick) {
       return ImmutableList.copyOf(servers);
     }
     List<QueryableDruidServer> list = Lists.newArrayList(servers);
     Collections.shuffle(list, ThreadLocalRandom.current());
-    return ImmutableList.copyOf(list.subList(0, Math.min(list.size(), numServersToPick)));
+    return ImmutableList.copyOf(list.subList(0, numServersToPick));
   }
 }

--- a/server/src/main/java/io/druid/client/selector/RandomServerSelectorStrategy.java
+++ b/server/src/main/java/io/druid/client/selector/RandomServerSelectorStrategy.java
@@ -20,8 +20,12 @@
 package io.druid.client.selector;
 
 import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
 import io.druid.timeline.DataSegment;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Random;
 import java.util.Set;
 
@@ -33,5 +37,15 @@ public class RandomServerSelectorStrategy implements ServerSelectorStrategy
   public QueryableDruidServer pick(Set<QueryableDruidServer> servers, DataSegment segment)
   {
     return Iterators.get(servers.iterator(), random.nextInt(servers.size()));
+  }
+
+  @Override
+  public List<QueryableDruidServer> pick(
+      Set<QueryableDruidServer> servers, DataSegment segment, int numServersToPick
+  )
+  {
+    List<QueryableDruidServer> list = Lists.newArrayList(servers);
+    Collections.shuffle(list);
+    return list.subList(0, numServersToPick);
   }
 }

--- a/server/src/main/java/io/druid/client/selector/RandomServerSelectorStrategy.java
+++ b/server/src/main/java/io/druid/client/selector/RandomServerSelectorStrategy.java
@@ -23,7 +23,6 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import io.druid.timeline.DataSegment;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
@@ -46,6 +45,6 @@ public class RandomServerSelectorStrategy implements ServerSelectorStrategy
   {
     List<QueryableDruidServer> list = Lists.newArrayList(servers);
     Collections.shuffle(list);
-    return list.subList(0, numServersToPick);
+    return list.subList(0, Math.min(list.size(), numServersToPick));
   }
 }

--- a/server/src/main/java/io/druid/client/selector/ServerSelector.java
+++ b/server/src/main/java/io/druid/client/selector/ServerSelector.java
@@ -63,11 +63,7 @@ public class ServerSelector implements DiscoverySelector<QueryableDruidServer>
     synchronized (this) {
       this.segment.set(segment);
       int priority = server.getServer().getPriority();
-      Set<QueryableDruidServer> priorityServers = servers.get(priority);
-      if (priorityServers == null) {
-        priorityServers = new HashSet<>();
-        servers.put(priority, priorityServers);
-      }
+      Set<QueryableDruidServer> priorityServers = servers.computeIfAbsent(priority, p -> new HashSet<>());
       priorityServers.add(server);
     }
   }

--- a/server/src/main/java/io/druid/client/selector/ServerSelector.java
+++ b/server/src/main/java/io/druid/client/selector/ServerSelector.java
@@ -21,12 +21,12 @@ package io.druid.client.selector;
 
 import io.druid.server.coordination.DruidServerMetadata;
 import io.druid.timeline.DataSegment;
+import it.unimi.dsi.fastutil.ints.Int2ObjectRBTreeMap;
 
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
 public class ServerSelector implements DiscoverySelector<QueryableDruidServer>
 {
 
-  private final TreeMap<Integer, Set<QueryableDruidServer>> servers;
+  private final Int2ObjectRBTreeMap<Set<QueryableDruidServer>> servers;
 
   private final TierSelectorStrategy strategy;
 
@@ -48,7 +48,7 @@ public class ServerSelector implements DiscoverySelector<QueryableDruidServer>
   {
     this.segment = new AtomicReference<>(segment);
     this.strategy = strategy;
-    this.servers = new TreeMap<>(strategy.getComparator());
+    this.servers = new Int2ObjectRBTreeMap<>(strategy.getComparator());
   }
 
   public DataSegment getSegment()

--- a/server/src/main/java/io/druid/client/selector/ServerSelectorStrategy.java
+++ b/server/src/main/java/io/druid/client/selector/ServerSelectorStrategy.java
@@ -21,7 +21,6 @@ package io.druid.client.selector;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.google.common.collect.Iterables;
 import io.druid.timeline.DataSegment;
 
 import java.util.List;

--- a/server/src/main/java/io/druid/client/selector/ServerSelectorStrategy.java
+++ b/server/src/main/java/io/druid/client/selector/ServerSelectorStrategy.java
@@ -21,8 +21,10 @@ package io.druid.client.selector;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.google.common.collect.Iterables;
 import io.druid.timeline.DataSegment;
 
+import java.util.List;
 import java.util.Set;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = RandomServerSelectorStrategy.class)
@@ -32,5 +34,7 @@ import java.util.Set;
 })
 public interface ServerSelectorStrategy
 {
-  public QueryableDruidServer pick(Set<QueryableDruidServer> servers, DataSegment segment);
+  QueryableDruidServer pick(Set<QueryableDruidServer> servers, DataSegment segment);
+
+  List<QueryableDruidServer> pick(Set<QueryableDruidServer> servers, DataSegment segment, int numServersToPick);
 }

--- a/server/src/main/java/io/druid/client/selector/TierSelectorStrategy.java
+++ b/server/src/main/java/io/druid/client/selector/TierSelectorStrategy.java
@@ -22,11 +22,11 @@ package io.druid.client.selector;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.druid.timeline.DataSegment;
+import it.unimi.dsi.fastutil.ints.Int2ObjectRBTreeMap;
 
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
-import java.util.SortedMap;
 
 /**
  */
@@ -40,10 +40,10 @@ public interface TierSelectorStrategy
 {
   Comparator<Integer> getComparator();
 
-  QueryableDruidServer pick(SortedMap<Integer, Set<QueryableDruidServer>> prioritizedServers, DataSegment segment);
+  QueryableDruidServer pick(Int2ObjectRBTreeMap<Set<QueryableDruidServer>> prioritizedServers, DataSegment segment);
 
   List<QueryableDruidServer> pick(
-      SortedMap<Integer, Set<QueryableDruidServer>> prioritizedServers,
+      Int2ObjectRBTreeMap<Set<QueryableDruidServer>> prioritizedServers,
       DataSegment segment,
       int numServersToPick
   );

--- a/server/src/main/java/io/druid/client/selector/TierSelectorStrategy.java
+++ b/server/src/main/java/io/druid/client/selector/TierSelectorStrategy.java
@@ -26,7 +26,7 @@ import io.druid.timeline.DataSegment;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
-import java.util.TreeMap;
+import java.util.SortedMap;
 
 /**
  */
@@ -40,11 +40,11 @@ public interface TierSelectorStrategy
 {
   Comparator<Integer> getComparator();
 
-  QueryableDruidServer pick(TreeMap<Integer, Set<QueryableDruidServer>> prioritizedServers, DataSegment segment);
+  QueryableDruidServer pick(SortedMap<Integer, Set<QueryableDruidServer>> prioritizedServers, DataSegment segment);
 
   List<QueryableDruidServer> pick(
-      TreeMap<Integer, Set<QueryableDruidServer>> prioritizedServers,
+      SortedMap<Integer, Set<QueryableDruidServer>> prioritizedServers,
       DataSegment segment,
-      int numServerToPick
+      int numServersToPick
   );
 }

--- a/server/src/main/java/io/druid/client/selector/TierSelectorStrategy.java
+++ b/server/src/main/java/io/druid/client/selector/TierSelectorStrategy.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.druid.timeline.DataSegment;
 
 import java.util.Comparator;
+import java.util.List;
 import java.util.Set;
 import java.util.TreeMap;
 
@@ -37,7 +38,13 @@ import java.util.TreeMap;
 })
 public interface TierSelectorStrategy
 {
-  public Comparator<Integer> getComparator();
+  Comparator<Integer> getComparator();
 
-  public QueryableDruidServer pick(TreeMap<Integer, Set<QueryableDruidServer>> prioritizedServers, DataSegment segment);
+  QueryableDruidServer pick(TreeMap<Integer, Set<QueryableDruidServer>> prioritizedServers, DataSegment segment);
+
+  List<QueryableDruidServer> pick(
+      TreeMap<Integer, Set<QueryableDruidServer>> prioritizedServers,
+      DataSegment segment,
+      int numServerToPick
+  );
 }

--- a/server/src/test/java/io/druid/client/CachingClusteredClientFunctionalityTest.java
+++ b/server/src/test/java/io/druid/client/CachingClusteredClientFunctionalityTest.java
@@ -39,6 +39,7 @@ import io.druid.timeline.DataSegment;
 import io.druid.timeline.VersionedIntervalTimeline;
 import io.druid.timeline.partition.NoneShardSpec;
 import io.druid.timeline.partition.SingleElementPartitionChunk;
+import it.unimi.dsi.fastutil.ints.Int2ObjectRBTreeMap;
 import org.easymock.EasyMock;
 import org.joda.time.Interval;
 import org.junit.Assert;
@@ -52,7 +53,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.SortedMap;
 import java.util.concurrent.Executor;
 
 /**
@@ -157,7 +157,7 @@ public class CachingClusteredClientFunctionalityTest {
               }
 
               @Override
-              public QueryableDruidServer pick(SortedMap<Integer, Set<QueryableDruidServer>> prioritizedServers, DataSegment segment) {
+              public QueryableDruidServer pick(Int2ObjectRBTreeMap<Set<QueryableDruidServer>> prioritizedServers, DataSegment segment) {
                 return new QueryableDruidServer(
                     new DruidServer("localhost", "localhost", 100, "historical", "a", 10),
                     EasyMock.createNiceMock(DirectDruidClient.class)
@@ -166,7 +166,7 @@ public class CachingClusteredClientFunctionalityTest {
 
               @Override
               public List<QueryableDruidServer> pick(
-                  SortedMap<Integer, Set<QueryableDruidServer>> prioritizedServers,
+                  Int2ObjectRBTreeMap<Set<QueryableDruidServer>> prioritizedServers,
                   DataSegment segment,
                   int numServerToPick
               )

--- a/server/src/test/java/io/druid/client/CachingClusteredClientFunctionalityTest.java
+++ b/server/src/test/java/io/druid/client/CachingClusteredClientFunctionalityTest.java
@@ -52,7 +52,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
+import java.util.SortedMap;
 import java.util.concurrent.Executor;
 
 /**
@@ -157,7 +157,7 @@ public class CachingClusteredClientFunctionalityTest {
               }
 
               @Override
-              public QueryableDruidServer pick(TreeMap<Integer, Set<QueryableDruidServer>> prioritizedServers, DataSegment segment) {
+              public QueryableDruidServer pick(SortedMap<Integer, Set<QueryableDruidServer>> prioritizedServers, DataSegment segment) {
                 return new QueryableDruidServer(
                     new DruidServer("localhost", "localhost", 100, "historical", "a", 10),
                     EasyMock.createNiceMock(DirectDruidClient.class)
@@ -166,7 +166,7 @@ public class CachingClusteredClientFunctionalityTest {
 
               @Override
               public List<QueryableDruidServer> pick(
-                  TreeMap<Integer, Set<QueryableDruidServer>> prioritizedServers,
+                  SortedMap<Integer, Set<QueryableDruidServer>> prioritizedServers,
                   DataSegment segment,
                   int numServerToPick
               )

--- a/server/src/test/java/io/druid/client/CachingClusteredClientFunctionalityTest.java
+++ b/server/src/test/java/io/druid/client/CachingClusteredClientFunctionalityTest.java
@@ -168,7 +168,7 @@ public class CachingClusteredClientFunctionalityTest {
               public List<QueryableDruidServer> pick(
                   Int2ObjectRBTreeMap<Set<QueryableDruidServer>> prioritizedServers,
                   DataSegment segment,
-                  int numServerToPick
+                  int numServersToPick
               )
               {
                 return Collections.singletonList(new QueryableDruidServer(

--- a/server/src/test/java/io/druid/client/CachingClusteredClientFunctionalityTest.java
+++ b/server/src/test/java/io/druid/client/CachingClusteredClientFunctionalityTest.java
@@ -46,6 +46,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -161,6 +162,19 @@ public class CachingClusteredClientFunctionalityTest {
                     new DruidServer("localhost", "localhost", 100, "historical", "a", 10),
                     EasyMock.createNiceMock(DirectDruidClient.class)
                 );
+              }
+
+              @Override
+              public List<QueryableDruidServer> pick(
+                  TreeMap<Integer, Set<QueryableDruidServer>> prioritizedServers,
+                  DataSegment segment,
+                  int numServerToPick
+              )
+              {
+                return Collections.singletonList(new QueryableDruidServer(
+                    new DruidServer("localhost", "localhost", 100, "historical", "a", 10),
+                    EasyMock.createNiceMock(DirectDruidClient.class)
+                ));
               }
             }
         )

--- a/server/src/test/java/io/druid/client/selector/ServerSelectorTest.java
+++ b/server/src/test/java/io/druid/client/selector/ServerSelectorTest.java
@@ -21,17 +21,28 @@ package io.druid.client.selector;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.druid.client.DirectDruidClient;
+import io.druid.client.DruidServer;
 import io.druid.timeline.DataSegment;
 import io.druid.timeline.partition.NoneShardSpec;
 import org.easymock.EasyMock;
 import org.joda.time.Interval;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 /**
  */
 public class ServerSelectorTest
 {
+  TierSelectorStrategy tierSelectorStrategy;
+
+  @Before
+  public void setUp() throws Exception
+  {
+    tierSelectorStrategy = EasyMock.createMock(TierSelectorStrategy.class);
+    EasyMock.expect(tierSelectorStrategy.getComparator()).andReturn(Integer::compare).anyTimes();
+  }
 
   @Test
   public void testSegmentUpdate() throws Exception
@@ -59,7 +70,10 @@ public class ServerSelectorTest
     );
 
     selector.addServerAndUpdateSegment(
-        EasyMock.createMock(QueryableDruidServer.class),
+        new QueryableDruidServer(
+            new DruidServer("test1", "localhost", 0, "historical", DruidServer.DEFAULT_TIER, 1),
+            EasyMock.createMock(DirectDruidClient.class)
+        ),
         DataSegment.builder()
                    .dataSource(
                        "test_broker_server_view")

--- a/server/src/test/java/io/druid/server/ClientInfoResourceTest.java
+++ b/server/src/test/java/io/druid/server/ClientInfoResourceTest.java
@@ -43,6 +43,8 @@ import com.google.common.collect.Ordering;
 import io.druid.client.DruidServer;
 import io.druid.client.FilteredServerInventoryView;
 import io.druid.client.TimelineServerView;
+import io.druid.client.selector.HighestPriorityTierSelectorStrategy;
+import io.druid.client.selector.RandomServerSelectorStrategy;
 import io.druid.client.selector.ServerSelector;
 import io.druid.query.TableDataSource;
 import io.druid.query.metadata.SegmentMetadataQueryConfig;
@@ -377,7 +379,7 @@ public class ClientInfoResourceTest
                                      .size(1)
                                      .build();
     server.addDataSegment(segment.getIdentifier(), segment);
-    ServerSelector ss = new ServerSelector(segment, null);
+    ServerSelector ss = new ServerSelector(segment, new HighestPriorityTierSelectorStrategy(new RandomServerSelectorStrategy()));
     timeline.add(new Interval(interval), version, new SingleElementPartitionChunk<ServerSelector>(ss));
   }
 
@@ -401,7 +403,7 @@ public class ClientInfoResourceTest
                                      .size(1)
                                      .build();
     server.addDataSegment(segment.getIdentifier(), segment);
-    ServerSelector ss = new ServerSelector(segment, null);
+    ServerSelector ss = new ServerSelector(segment, new HighestPriorityTierSelectorStrategy(new RandomServerSelectorStrategy()));
     timeline.add(new Interval(interval), version, shardSpec.createChunk(ss));
   }
 


### PR DESCRIPTION
This PR intended to slightly improve ServerSelector class:

1. Get rid of TreeMap creation on each call to pick() method and store servers in TreeMap instead. Pick() is called for every segment for each query on broker side, so a lot of temp collections are created
2. Use Int2ObjectRBTreeMap instead of TreeMap and change TierSelectorStrategy interface to accept SortedMap instead of TreeMap
3. Pick method in TierSelectorStrategy does not modify input map anymore
4. Extend ServerSelectStrategy and TierSelectorStrategy interfaces with method for multiple instance selection and use it in ServerSelector to simplify logic and keep all selection details in strategy implementation