### PR TITLE
[BACKEND-810] Replace usages of CountingMap with Object2LongMap

### DIFF
--- a/indexing-hadoop/pom.xml
+++ b/indexing-hadoop/pom.xml
@@ -98,6 +98,10 @@
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
         </dependency>
+        <dependency>
+            <groupId>it.unimi.dsi</groupId>
+            <artifactId>fastutil</artifactId>
+        </dependency>
 
         <!-- Tests -->
         <dependency>

--- a/indexing-hadoop/src/main/java/io/druid/indexer/hadoop/DatasourceInputFormat.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/hadoop/DatasourceInputFormat.java
@@ -26,8 +26,8 @@ import com.google.common.base.Supplier;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
 
-import io.druid.collections.CountingMap;
 import io.druid.data.input.InputRow;
 import io.druid.indexer.HadoopDruidIndexerConfig;
 import io.druid.indexer.JobHelper;
@@ -219,10 +219,9 @@ public class DatasourceInputFormat extends InputFormat<NullWritable, InputRow>
 
   private static String[] getFrequentLocations(Iterable<String> hosts)
   {
-
-    final CountingMap<String> counter = new CountingMap<>();
+    final Object2LongOpenHashMap<String> counter = new Object2LongOpenHashMap<>();
     for (String location : hosts) {
-      counter.add(location, 1);
+      counter.addTo(location, 1);
     }
 
     final TreeSet<Pair<Long, String>> sorted = Sets.<Pair<Long, String>>newTreeSet(
@@ -240,8 +239,8 @@ public class DatasourceInputFormat extends InputFormat<NullWritable, InputRow>
         }
     );
 
-    for (Map.Entry<String, AtomicLong> entry : counter.entrySet()) {
-      sorted.add(Pair.of(entry.getValue().get(), entry.getKey()));
+    for (Map.Entry<String, Long> entry : counter.entrySet()) {
+      sorted.add(Pair.of(entry.getValue(), entry.getKey()));
     }
 
     // use default replication factor, if possible

--- a/indexing-hadoop/src/main/java/io/druid/indexer/hadoop/DatasourceInputFormat.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/hadoop/DatasourceInputFormat.java
@@ -23,17 +23,12 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
-import it.unimi.dsi.fastutil.objects.Object2LongMap;
-import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
 
 import io.druid.data.input.InputRow;
 import io.druid.indexer.HadoopDruidIndexerConfig;
 import io.druid.indexer.JobHelper;
 import io.druid.java.util.common.ISE;
-import io.druid.java.util.common.Pair;
 import io.druid.java.util.common.logger.Logger;
 
 import org.apache.hadoop.conf.Configuration;
@@ -55,9 +50,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Iterator;
 import java.util.List;
-import java.util.TreeSet;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class DatasourceInputFormat extends InputFormat<NullWritable, InputRow>
 {
@@ -191,66 +187,56 @@ public class DatasourceInputFormat extends InputFormat<NullWritable, InputRow>
       JobConf conf
   )
   {
-    String[] locations = null;
-    try {
-      locations = getFrequentLocations(segments, fio, conf);
-    }
-    catch (Exception e) {
-      logger.error(e, "Exception thrown finding location of splits");
-    }
+    String[] locations = getFrequentLocations(segments, fio, conf);
+
     return new DatasourceInputSplit(segments, locations);
   }
 
   private String[] getFrequentLocations(
-      List<WindowedDataSegment> segments,
-      org.apache.hadoop.mapred.InputFormat fio,
-      JobConf conf
-  ) throws IOException
+      final List<WindowedDataSegment> segments,
+      final org.apache.hadoop.mapred.InputFormat fio,
+      final JobConf conf
+  )
   {
-    Iterable<String> locations = Collections.emptyList();
-    for (WindowedDataSegment segment : segments) {
-      FileInputFormat.setInputPaths(conf, new Path(JobHelper.getURIFromSegment(segment.getSegment())));
-      for (org.apache.hadoop.mapred.InputSplit split : fio.getSplits(conf, 1)) {
-        locations = Iterables.concat(locations, Arrays.asList(split.getLocations()));
-      }
-    }
-    return getFrequentLocations(locations);
-  }
-
-  private static String[] getFrequentLocations(Iterable<String> hosts)
-  {
-    final Object2LongOpenHashMap<String> counter = new Object2LongOpenHashMap<>();
-    for (String location : hosts) {
-      counter.addTo(location, 1);
-    }
-
-    final TreeSet<Pair<Long, String>> sorted = Sets.<Pair<Long, String>>newTreeSet(
-        new Comparator<Pair<Long, String>>()
-        {
-          @Override
-          public int compare(Pair<Long, String> o1, Pair<Long, String> o2)
-          {
-            int compare = o2.lhs.compareTo(o1.lhs); // descending
-            if (compare == 0) {
-              compare = o1.rhs.compareTo(o2.rhs);   // ascending
-            }
-            return compare;
+    final Stream<String> locations = segments.stream().flatMap(
+        (final WindowedDataSegment segment) -> {
+          FileInputFormat.setInputPaths(
+              conf,
+              new Path(JobHelper.getURIFromSegment(segment.getSegment()))
+          );
+          try {
+            return Arrays.stream(fio.getSplits(conf, 1)).flatMap(
+                (final org.apache.hadoop.mapred.InputSplit split) -> {
+                  try {
+                    return Arrays.stream(split.getLocations());
+                  }
+                  catch (final IOException e) {
+                    logger.error(e, "Exception getting locations");
+                    return Stream.empty();
+                  }
+                }
+            );
+          }
+          catch (final IOException e) {
+            logger.error(e, "Exception getting splits");
+            return Stream.empty();
           }
         }
     );
 
-    for (final Iterator<Object2LongMap.Entry<String>> entries =
-         counter.object2LongEntrySet().fastIterator();
-         entries.hasNext(); ) {
-      final Object2LongMap.Entry<String> entry = entries.next();
-      sorted.add(Pair.of(entry.getValue(), entry.getKey()));
-    }
+    final Map<String, Long> locationCountMap = locations.collect(
+        Collectors.groupingBy(location -> location, Collectors.counting())
+    );
 
-    // use default replication factor, if possible
-    final List<String> locations = Lists.newArrayListWithCapacity(3);
-    for (Pair<Long, String> frequent : Iterables.limit(sorted, 3)) {
-      locations.add(frequent.rhs);
-    }
-    return locations.toArray(new String[locations.size()]);
+    Comparator<Map.Entry<String, Long>> comparator =
+        Map.Entry.comparingByValue(Comparator.reverseOrder());
+    comparator = comparator.thenComparing(Map.Entry.comparingByKey());
+
+    return locationCountMap
+        .entrySet().stream()
+        .sorted(comparator)
+        .limit(3)
+        .map(Map.Entry::getKey)
+        .toArray(String[]::new);
   }
 }

--- a/indexing-hadoop/src/main/java/io/druid/indexer/hadoop/DatasourceInputFormat.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/hadoop/DatasourceInputFormat.java
@@ -26,6 +26,7 @@ import com.google.common.base.Supplier;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import it.unimi.dsi.fastutil.objects.Object2LongMap;
 import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
 
 import io.druid.data.input.InputRow;
@@ -54,10 +55,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.TreeSet;
-import java.util.concurrent.atomic.AtomicLong;
 
 public class DatasourceInputFormat extends InputFormat<NullWritable, InputRow>
 {
@@ -239,7 +239,10 @@ public class DatasourceInputFormat extends InputFormat<NullWritable, InputRow>
         }
     );
 
-    for (Map.Entry<String, Long> entry : counter.entrySet()) {
+    for (final Iterator<Object2LongMap.Entry<String>> entries =
+         counter.object2LongEntrySet().fastIterator();
+         entries.hasNext(); ) {
+      final Object2LongMap.Entry<String> entry = entries.next();
       sorted.add(Pair.of(entry.getValue(), entry.getKey()));
     }
 

--- a/indexing-hadoop/src/main/java/io/druid/indexer/hadoop/DatasourceInputFormat.java
+++ b/indexing-hadoop/src/main/java/io/druid/indexer/hadoop/DatasourceInputFormat.java
@@ -228,13 +228,15 @@ public class DatasourceInputFormat extends InputFormat<NullWritable, InputRow>
         Collectors.groupingBy(location -> location, Collectors.counting())
     );
 
-    Comparator<Map.Entry<String, Long>> comparator =
+    final Comparator<Map.Entry<String, Long>> valueComparator =
         Map.Entry.comparingByValue(Comparator.reverseOrder());
-    comparator = comparator.thenComparing(Map.Entry.comparingByKey());
+
+    final Comparator<Map.Entry<String, Long>> keyComparator =
+        Map.Entry.comparingByKey();
 
     return locationCountMap
         .entrySet().stream()
-        .sorted(comparator)
+        .sorted(valueComparator.thenComparing(keyComparator))
         .limit(3)
         .map(Map.Entry::getKey)
         .toArray(String[]::new);

--- a/pom.xml
+++ b/pom.xml
@@ -656,6 +656,11 @@
                 <artifactId>asm-commons</artifactId>
                 <version>5.2</version>
             </dependency>
+            <dependency>
+                <groupId>it.unimi.dsi</groupId>
+                <artifactId>fastutil</artifactId>
+                <version>6.5.7</version>
+            </dependency>
 
             <!-- Test Scope -->
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -656,11 +656,6 @@
                 <artifactId>asm-commons</artifactId>
                 <version>5.2</version>
             </dependency>
-            <dependency>
-                <groupId>it.unimi.dsi</groupId>
-                <artifactId>fastutil</artifactId>
-                <version>6.5.7</version>
-            </dependency>
 
             <!-- Test Scope -->
             <dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -185,6 +185,10 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math3</artifactId>
         </dependency>
+        <dependency>
+            <groupId>it.unimi.dsi</groupId>
+            <artifactId>fastutil</artifactId>
+        </dependency>
 
         <!-- Tests -->
         <dependency>

--- a/server/src/main/java/io/druid/server/coordination/ServerManager.java
+++ b/server/src/main/java/io/druid/server/coordination/ServerManager.java
@@ -62,6 +62,7 @@ import io.druid.timeline.TimelineObjectHolder;
 import io.druid.timeline.VersionedIntervalTimeline;
 import io.druid.timeline.partition.PartitionChunk;
 import io.druid.timeline.partition.PartitionHolder;
+import it.unimi.dsi.fastutil.objects.Object2LongMap;
 import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
 import org.joda.time.Interval;
 
@@ -70,9 +71,11 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.ObjLongConsumer;
 
 /**
  */
@@ -117,17 +120,31 @@ public class ServerManager implements QuerySegmentWalker
     this.cacheConfig = cacheConfig;
   }
 
-  public Map<String, Long> getDataSourceSizes()
+  public void forEachDataSourceSize(
+      final ObjLongConsumer<String> consumer
+  )
   {
     synchronized (dataSourceSizes) {
-      return dataSourceSizes.clone();
+      for (final Iterator<Object2LongMap.Entry<String>> entries =
+           dataSourceSizes.object2LongEntrySet().fastIterator();
+           entries.hasNext(); ) {
+        final Object2LongMap.Entry<String> entry = entries.next();
+        consumer.accept(entry.getKey(), entry.getLongValue());
+      }
     }
   }
 
-  public Map<String, Long> getDataSourceCounts()
+  public void forEachDataSourceCount(
+      final ObjLongConsumer<String> consumer
+  )
   {
     synchronized (dataSourceCounts) {
-      return dataSourceCounts.clone();
+      for (final Iterator<Object2LongMap.Entry<String>> entries =
+           dataSourceCounts.object2LongEntrySet().fastIterator();
+           entries.hasNext(); ) {
+        final Object2LongMap.Entry<String> entry = entries.next();
+        consumer.accept(entry.getKey(), entry.getLongValue());
+      }
     }
   }
 

--- a/server/src/main/java/io/druid/server/coordination/ServerManager.java
+++ b/server/src/main/java/io/druid/server/coordination/ServerManager.java
@@ -71,7 +71,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
@@ -125,10 +124,7 @@ public class ServerManager implements QuerySegmentWalker
   )
   {
     synchronized (dataSourceSizes) {
-      for (final Iterator<Object2LongMap.Entry<String>> entries =
-           dataSourceSizes.object2LongEntrySet().fastIterator();
-           entries.hasNext(); ) {
-        final Object2LongMap.Entry<String> entry = entries.next();
+      for (final Object2LongMap.Entry<String> entry : dataSourceSizes.object2LongEntrySet()) {
         consumer.accept(entry.getKey(), entry.getLongValue());
       }
     }
@@ -139,10 +135,7 @@ public class ServerManager implements QuerySegmentWalker
   )
   {
     synchronized (dataSourceCounts) {
-      for (final Iterator<Object2LongMap.Entry<String>> entries =
-           dataSourceCounts.object2LongEntrySet().fastIterator();
-           entries.hasNext(); ) {
-        final Object2LongMap.Entry<String> entry = entries.next();
+      for (final Object2LongMap.Entry<String> entry : dataSourceCounts.object2LongEntrySet()) {
         consumer.accept(entry.getKey(), entry.getLongValue());
       }
     }
@@ -184,12 +177,11 @@ public class ServerManager implements QuerySegmentWalker
 
     synchronized (lock) {
       String dataSource = segment.getDataSource();
-      VersionedIntervalTimeline<String, ReferenceCountingSegment> loadedIntervals = dataSources.get(dataSource);
-
-      if (loadedIntervals == null) {
-        loadedIntervals = new VersionedIntervalTimeline<>(Ordering.natural());
-        dataSources.put(dataSource, loadedIntervals);
-      }
+      final VersionedIntervalTimeline<String, ReferenceCountingSegment> loadedIntervals =
+          dataSources.computeIfAbsent(
+              dataSource,
+              ignored -> new VersionedIntervalTimeline<>(Ordering.natural())
+          );
 
       PartitionHolder<ReferenceCountingSegment> entry = loadedIntervals.findEntry(
           segment.getInterval(),
@@ -226,7 +218,7 @@ public class ServerManager implements QuerySegmentWalker
         return;
       }
 
-      PartitionChunk<ReferenceCountingSegment> removed = loadedIntervals.remove(
+      final PartitionChunk<ReferenceCountingSegment> removed = loadedIntervals.remove(
           segment.getInterval(),
           segment.getVersion(),
           segment.getShardSpec().createChunk((ReferenceCountingSegment) null)

--- a/server/src/main/java/io/druid/server/coordination/ServerManager.java
+++ b/server/src/main/java/io/druid/server/coordination/ServerManager.java
@@ -119,9 +119,7 @@ public class ServerManager implements QuerySegmentWalker
     this.cacheConfig = cacheConfig;
   }
 
-  public void forEachDataSourceSize(
-      final ObjLongConsumer<String> consumer
-  )
+  public void forEachDataSourceSize(final ObjLongConsumer<String> consumer)
   {
     synchronized (dataSourceSizes) {
       for (final Object2LongMap.Entry<String> entry : dataSourceSizes.object2LongEntrySet()) {
@@ -130,9 +128,7 @@ public class ServerManager implements QuerySegmentWalker
     }
   }
 
-  public void forEachDataSourceCount(
-      final ObjLongConsumer<String> consumer
-  )
+  public void forEachDataSourceCount(final ObjLongConsumer<String> consumer)
   {
     synchronized (dataSourceCounts) {
       for (final Object2LongMap.Entry<String> entry : dataSourceCounts.object2LongEntrySet()) {

--- a/server/src/main/java/io/druid/server/coordination/ServerManager.java
+++ b/server/src/main/java/io/druid/server/coordination/ServerManager.java
@@ -62,7 +62,6 @@ import io.druid.timeline.TimelineObjectHolder;
 import io.druid.timeline.VersionedIntervalTimeline;
 import io.druid.timeline.partition.PartitionChunk;
 import io.druid.timeline.partition.PartitionHolder;
-import it.unimi.dsi.fastutil.objects.Object2LongMap;
 import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
 import org.joda.time.Interval;
 

--- a/server/src/main/java/io/druid/server/coordinator/CoordinatorStats.java
+++ b/server/src/main/java/io/druid/server/coordinator/CoordinatorStats.java
@@ -41,15 +41,12 @@ public class CoordinatorStats
     globalStats = new Object2LongOpenHashMap<>();
   }
 
-  public boolean hasPerTierStats(
-  )
+  public boolean hasPerTierStats()
   {
     return !perTierStats.isEmpty();
   }
 
-  public Set<String> getTiers(
-      final String statName
-  )
+  public Set<String> getTiers(final String statName)
   {
     final Object2LongOpenHashMap<String> theStat = perTierStats.get(statName);
     if (theStat == null) {
@@ -65,18 +62,12 @@ public class CoordinatorStats
    * @return the value for the statistics {@code statName} under {@code tier} tier
    * @throws NullPointerException if {@code statName} is not found
    */
-  public long getTieredStat(
-      final String statName,
-      final String tier
-  )
+  public long getTieredStat(final String statName, final String tier)
   {
     return perTierStats.get(statName).getLong(tier);
   }
 
-  public void forEachTieredStat(
-      final String statName,
-      final ObjLongConsumer<String> consumer
-  )
+  public void forEachTieredStat(final String statName, final ObjLongConsumer<String> consumer)
   {
     final Object2LongOpenHashMap<String> theStat = perTierStats.get(statName);
     if (theStat != null) {
@@ -86,34 +77,23 @@ public class CoordinatorStats
     }
   }
 
-  public long getGlobalStat(
-      final String statName
-  )
+  public long getGlobalStat(final String statName)
   {
     return globalStats.getLong(statName);
   }
 
-  public void addToTieredStat(
-      final String statName,
-      final String tier,
-      final long value
-  )
+  public void addToTieredStat(final String statName, final String tier, final long value)
   {
     perTierStats.computeIfAbsent(statName, ignored -> new Object2LongOpenHashMap<>())
                 .addTo(tier, value);
   }
 
-  public void addToGlobalStat(
-      final String statName,
-      final long value
-  )
+  public void addToGlobalStat(final String statName, final long value)
   {
     globalStats.addTo(statName, value);
   }
 
-  public CoordinatorStats accumulate(
-      final CoordinatorStats stats
-  )
+  public CoordinatorStats accumulate(final CoordinatorStats stats)
   {
     stats.perTierStats.forEach(
         (final String statName, final Object2LongOpenHashMap<String> urStat) -> {

--- a/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
@@ -292,9 +292,7 @@ public class DruidCoordinator
     return retVal;
   }
 
-  boolean hasLoadPending(
-      final String dataSource
-  )
+  boolean hasLoadPending(final String dataSource)
   {
     return loadManagementPeons
         .values()

--- a/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
+++ b/server/src/main/java/io/druid/server/coordinator/DruidCoordinator.java
@@ -69,6 +69,7 @@ import io.druid.server.coordinator.rules.Rule;
 import io.druid.server.initialization.ZkPathsConfig;
 import io.druid.server.lookup.cache.LookupCoordinatorManager;
 import io.druid.timeline.DataSegment;
+import it.unimi.dsi.fastutil.objects.Object2LongMap;
 import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.leader.LeaderLatch;
@@ -84,6 +85,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentMap;
@@ -230,7 +232,7 @@ public class DruidCoordinator
     return loadManagementPeons;
   }
 
-  public Map<String, Object2LongOpenHashMap<String>> getReplicationStatus()
+  public Map<String, ? extends Object2LongMap<String>> getReplicationStatus()
   {
     final Map<String, Object2LongOpenHashMap<String>> retVal = Maps.newHashMap();
 
@@ -239,38 +241,40 @@ public class DruidCoordinator
     }
 
     final DateTime now = new DateTime();
-    for (DataSegment segment : getAvailableDataSegments()) {
-      List<Rule> rules = metadataRuleManager.getRulesWithDefault(segment.getDataSource());
-      for (Rule rule : rules) {
-        if (rule instanceof LoadRule && rule.appliesTo(segment, now)) {
-          for (Map.Entry<String, Integer> entry : ((LoadRule) rule).getTieredReplicants()
-                                                                   .entrySet()) {
-            Object2LongOpenHashMap<String> dataSourceMap = retVal.get(entry.getKey());
-            if (dataSourceMap == null) {
-              dataSourceMap = new Object2LongOpenHashMap<>();
-              retVal.put(entry.getKey(), dataSourceMap);
-            }
 
-            int diff = Math.max(
-                entry.getValue() -
-                segmentReplicantLookup.getTotalReplicants(
-                    segment.getIdentifier(),
-                    entry.getKey()
-                ),
-                0
-            );
-            dataSourceMap.addTo(segment.getDataSource(), diff);
-          }
-          break;
-        }
-      }
+    for (final DataSegment segment : getAvailableDataSegments()) {
+      final List<Rule> rules = metadataRuleManager.getRulesWithDefault(segment.getDataSource());
+
+      final Optional<Rule> rule = rules
+          .stream()
+          .filter((final Rule r) -> r instanceof LoadRule && r.appliesTo(segment, now))
+          .findFirst();
+
+      rule.map((final Rule r) -> (LoadRule) r)
+          .ifPresent(
+              (final LoadRule r) -> {
+                r.getTieredReplicants()
+                 .forEach(
+                     (final String tier, final Integer numReplicants) -> {
+                       final int diff =
+                           numReplicants -
+                           segmentReplicantLookup.getTotalReplicants(
+                               segment.getIdentifier(), tier
+                           );
+                       retVal
+                           .computeIfAbsent(tier, ignored -> new Object2LongOpenHashMap<>())
+                           .addTo(segment.getDataSource(), Math.max(diff, 0));
+                     }
+                 );
+              }
+          );
     }
 
     return retVal;
   }
 
 
-  public Object2LongOpenHashMap<String> getSegmentAvailability()
+  public Object2LongMap<String> getSegmentAvailability()
   {
     final Object2LongOpenHashMap<String> retVal = new Object2LongOpenHashMap<>();
 
@@ -288,15 +292,15 @@ public class DruidCoordinator
     return retVal;
   }
 
-  Object2LongOpenHashMap<String> getLoadPendingDatasources()
+  boolean hasLoadPending(
+      final String dataSource
+  )
   {
-    final Object2LongOpenHashMap<String> retVal = new Object2LongOpenHashMap<>();
-    for (LoadQueuePeon peon : loadManagementPeons.values()) {
-      for (DataSegment segment : peon.getSegmentsToLoad()) {
-        retVal.addTo(segment.getDataSource(), 1);
-      }
-    }
-    return retVal;
+    return loadManagementPeons
+        .values()
+        .stream()
+        .flatMap((final LoadQueuePeon peon) -> peon.getSegmentsToLoad().stream())
+        .anyMatch((final DataSegment segment) -> segment.getDataSource().equals(dataSource));
   }
 
   public Map<String, Double> getLoadStatus()

--- a/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorLogger.java
+++ b/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorLogger.java
@@ -35,8 +35,10 @@ import io.druid.server.coordinator.DruidCoordinatorRuntimeParams;
 import io.druid.server.coordinator.LoadQueuePeon;
 import io.druid.server.coordinator.ServerHolder;
 import io.druid.timeline.DataSegment;
+import it.unimi.dsi.fastutil.objects.Object2LongMap;
 import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
 
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
@@ -278,7 +280,11 @@ public class DruidCoordinatorLogger implements DruidCoordinatorHelper
         segmentCounts.addTo(dataSource.getName(), 1L);
       }
     }
-    for (Map.Entry<String, Long> entry : segmentSizes.entrySet()) {
+    for (final Iterator<Object2LongMap.Entry<String>> entries =
+         segmentSizes.object2LongEntrySet().fastIterator();
+         entries.hasNext(); ) {
+      final Object2LongMap.Entry<String> entry = entries.next();
+
       String dataSource = entry.getKey();
       Long size = entry.getValue();
       emitter.emit(
@@ -288,7 +294,11 @@ public class DruidCoordinatorLogger implements DruidCoordinatorHelper
           )
       );
     }
-    for (Map.Entry<String, Long> entry : segmentCounts.entrySet()) {
+    for (final Iterator<Object2LongMap.Entry<String>> entries =
+         segmentCounts.object2LongEntrySet().fastIterator();
+         entries.hasNext();) {
+      final Object2LongMap.Entry<String> entry = entries.next();
+
       String dataSource = entry.getKey();
       Long count = entry.getValue();
       emitter.emit(
@@ -298,7 +308,6 @@ public class DruidCoordinatorLogger implements DruidCoordinatorHelper
           )
       );
     }
-
 
     return params;
   }

--- a/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorLogger.java
+++ b/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorLogger.java
@@ -40,7 +40,6 @@ import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
 
 /**
  */
@@ -291,8 +290,8 @@ public class DruidCoordinatorLogger implements DruidCoordinatorHelper
          entries.hasNext(); ) {
       final Object2LongMap.Entry<String> entry = entries.next();
 
-      String dataSource = entry.getKey();
-      Long size = entry.getValue();
+      final String dataSource = entry.getKey();
+      final long size = entry.getLongValue();
       emitter.emit(
           new ServiceMetricEvent.Builder()
               .setDimension(DruidMetrics.DATASOURCE, dataSource).build(
@@ -305,8 +304,8 @@ public class DruidCoordinatorLogger implements DruidCoordinatorHelper
          entries.hasNext();) {
       final Object2LongMap.Entry<String> entry = entries.next();
 
-      String dataSource = entry.getKey();
-      Long count = entry.getValue();
+      final String dataSource = entry.getKey();
+      final long count = entry.getLongValue();
       emitter.emit(
           new ServiceMetricEvent.Builder()
               .setDimension(DruidMetrics.DATASOURCE, dataSource).build(

--- a/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorLogger.java
+++ b/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorLogger.java
@@ -81,12 +81,12 @@ public class DruidCoordinatorLogger implements DruidCoordinatorHelper
     CoordinatorStats stats = params.getCoordinatorStats();
     ServiceEmitter emitter = params.getEmitter();
 
-    Map<String, AtomicLong> assigned = stats.getPerTierStats().get("assignedCount");
+    Map<String, Long> assigned = stats.getPerTierStats().get("assignedCount");
     if (assigned != null) {
-      for (Map.Entry<String, AtomicLong> entry : assigned.entrySet()) {
+      for (Map.Entry<String, Long> entry : assigned.entrySet()) {
         log.info(
             "[%s] : Assigned %s segments among %,d servers",
-            entry.getKey(), entry.getValue().get(), cluster.get(entry.getKey()).size()
+            entry.getKey(), entry.getValue(), cluster.get(entry.getKey()).size()
         );
       }
     }
@@ -96,12 +96,12 @@ public class DruidCoordinatorLogger implements DruidCoordinatorHelper
         assigned
     );
 
-    Map<String, AtomicLong> dropped = stats.getPerTierStats().get("droppedCount");
+    Map<String, Long> dropped = stats.getPerTierStats().get("droppedCount");
     if (dropped != null) {
-      for (Map.Entry<String, AtomicLong> entry : dropped.entrySet()) {
+      for (Map.Entry<String, Long> entry : dropped.entrySet()) {
         log.info(
             "[%s] : Dropped %s segments among %,d servers",
-            entry.getKey(), entry.getValue().get(), cluster.get(entry.getKey()).size()
+            entry.getKey(), entry.getValue(), cluster.get(entry.getKey()).size()
         );
       }
     }
@@ -131,16 +131,16 @@ public class DruidCoordinatorLogger implements DruidCoordinatorHelper
         stats.getPerTierStats().get("deletedCount")
     );
 
-    Map<String, AtomicLong> normalized = stats.getPerTierStats().get("normalizedInitialCostTimesOneThousand");
+    Map<String, Long> normalized = stats.getPerTierStats().get("normalizedInitialCostTimesOneThousand");
     if (normalized != null) {
       emitTieredStats(
           emitter, "segment/cost/normalized",
           Maps.transformEntries(
               normalized,
-              new Maps.EntryTransformer<String, AtomicLong, Number>()
+              new Maps.EntryTransformer<String, Long, Number>()
               {
                 @Override
-                public Number transformEntry(String key, AtomicLong value)
+                public Number transformEntry(String key, Long value)
                 {
                   return value.doubleValue() / 1000d;
                 }
@@ -149,12 +149,12 @@ public class DruidCoordinatorLogger implements DruidCoordinatorHelper
       );
     }
 
-    Map<String, AtomicLong> unneeded = stats.getPerTierStats().get("unneededCount");
+    Map<String, Long> unneeded = stats.getPerTierStats().get("unneededCount");
     if (unneeded != null) {
-      for (Map.Entry<String, AtomicLong> entry : unneeded.entrySet()) {
+      for (Map.Entry<String, Long> entry : unneeded.entrySet()) {
         log.info(
             "[%s] : Removed %s unneeded segments among %,d servers",
-            entry.getKey(), entry.getValue().get(), cluster.get(entry.getKey()).size()
+            entry.getKey(), entry.getValue(), cluster.get(entry.getKey()).size()
         );
       }
     }
@@ -170,21 +170,21 @@ public class DruidCoordinatorLogger implements DruidCoordinatorHelper
         )
     );
 
-    Map<String, AtomicLong> moved = stats.getPerTierStats().get("movedCount");
+    Map<String, Long> moved = stats.getPerTierStats().get("movedCount");
     if (moved != null) {
-      for (Map.Entry<String, AtomicLong> entry : moved.entrySet()) {
+      for (Map.Entry<String, Long> entry : moved.entrySet()) {
         log.info(
             "[%s] : Moved %,d segment(s)",
-            entry.getKey(), entry.getValue().get()
+            entry.getKey(), entry.getValue()
         );
       }
     }
-    final Map<String, AtomicLong> unmoved = stats.getPerTierStats().get("unmovedCount");
+    final Map<String, Long> unmoved = stats.getPerTierStats().get("unmovedCount");
     if (unmoved != null) {
-      for(Map.Entry<String, AtomicLong> entry : unmoved.entrySet()) {
+      for(Map.Entry<String, Long> entry : unmoved.entrySet()) {
         log.info(
             "[%s] : Let alone %,d segment(s)",
-            entry.getKey(), entry.getValue().get()
+            entry.getKey(), entry.getValue()
         );
       }
     }

--- a/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorLogger.java
+++ b/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorLogger.java
@@ -35,6 +35,7 @@ import io.druid.server.coordinator.DruidCoordinatorRuntimeParams;
 import io.druid.server.coordinator.LoadQueuePeon;
 import io.druid.server.coordinator.ServerHolder;
 import io.druid.timeline.DataSegment;
+import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
 
 import java.util.Map;
 import java.util.Set;
@@ -269,15 +270,15 @@ public class DruidCoordinatorLogger implements DruidCoordinatorHelper
     }
 
     // Emit segment metrics
-    CountingMap<String> segmentSizes = new CountingMap<String>();
-    CountingMap<String> segmentCounts = new CountingMap<String>();
+    final Object2LongOpenHashMap<String> segmentSizes = new Object2LongOpenHashMap<>();
+    final Object2LongOpenHashMap<String> segmentCounts = new Object2LongOpenHashMap<>();
     for (DruidDataSource dataSource : params.getDataSources()) {
       for (DataSegment segment : dataSource.getSegments()) {
-        segmentSizes.add(dataSource.getName(), segment.getSize());
-        segmentCounts.add(dataSource.getName(), 1L);
+        segmentSizes.addTo(dataSource.getName(), segment.getSize());
+        segmentCounts.addTo(dataSource.getName(), 1L);
       }
     }
-    for (Map.Entry<String, Long> entry : segmentSizes.snapshot().entrySet()) {
+    for (Map.Entry<String, Long> entry : segmentSizes.entrySet()) {
       String dataSource = entry.getKey();
       Long size = entry.getValue();
       emitter.emit(
@@ -287,7 +288,7 @@ public class DruidCoordinatorLogger implements DruidCoordinatorHelper
           )
       );
     }
-    for (Map.Entry<String, Long> entry : segmentCounts.snapshot().entrySet()) {
+    for (Map.Entry<String, Long> entry : segmentCounts.entrySet()) {
       String dataSource = entry.getKey();
       Long count = entry.getValue();
       emitter.emit(

--- a/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorSegmentMerger.java
+++ b/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorSegmentMerger.java
@@ -130,11 +130,11 @@ public class DruidCoordinatorSegmentMerger implements DruidCoordinatorHelper
       }
     }
 
-    log.info("Issued merge requests for %s segments", stats.getGlobalStats().get("mergedCount"));
+    log.info("Issued merge requests for %s segments", stats.getGlobalStat("mergedCount"));
 
     params.getEmitter().emit(
         new ServiceMetricEvent.Builder().build(
-            "coordinator/merge/count", stats.getGlobalStats().get("mergedCount")
+            "coordinator/merge/count", stats.getGlobalStat("mergedCount")
         )
     );
 

--- a/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorSegmentMerger.java
+++ b/server/src/main/java/io/druid/server/coordinator/helper/DruidCoordinatorSegmentMerger.java
@@ -130,7 +130,7 @@ public class DruidCoordinatorSegmentMerger implements DruidCoordinatorHelper
       }
     }
 
-    log.info("Issued merge requests for %s segments", stats.getGlobalStats().get("mergedCount").get());
+    log.info("Issued merge requests for %s segments", stats.getGlobalStats().get("mergedCount"));
 
     params.getEmitter().emit(
         new ServiceMetricEvent.Builder().build(

--- a/server/src/main/java/io/druid/server/coordinator/rules/LoadRule.java
+++ b/server/src/main/java/io/druid/server/coordinator/rules/LoadRule.java
@@ -84,7 +84,7 @@ public abstract class LoadRule implements Rule
             segment
         );
         stats.accumulate(assignStats);
-        totalReplicantsInCluster += assignStats.getPerTierStats().get(ASSIGNED_COUNT).getLong(tier);
+        totalReplicantsInCluster += assignStats.getTieredStat(ASSIGNED_COUNT, tier);
       }
 
       loadStatus.put(tier, expectedReplicantsInTier - loadedReplicantsInTier);

--- a/server/src/main/java/io/druid/server/coordinator/rules/LoadRule.java
+++ b/server/src/main/java/io/druid/server/coordinator/rules/LoadRule.java
@@ -84,7 +84,7 @@ public abstract class LoadRule implements Rule
             segment
         );
         stats.accumulate(assignStats);
-        totalReplicantsInCluster += assignStats.getPerTierStats().get(ASSIGNED_COUNT).get(tier).get();
+        totalReplicantsInCluster += assignStats.getPerTierStats().get(ASSIGNED_COUNT).getLong(tier);
       }
 
       loadStatus.put(tier, expectedReplicantsInTier - loadedReplicantsInTier);

--- a/server/src/main/java/io/druid/server/metrics/HistoricalMetricsMonitor.java
+++ b/server/src/main/java/io/druid/server/metrics/HistoricalMetricsMonitor.java
@@ -66,7 +66,7 @@ public class HistoricalMetricsMonitor extends AbstractMonitor
 
     for (final Iterator<Object2LongMap.Entry<String>> entries =
          pendingDeleteSizes.object2LongEntrySet().fastIterator();
-         entries.hasNext();) {
+         entries.hasNext(); ) {
       final Object2LongMap.Entry<String> entry = entries.next();
 
       final String dataSource = entry.getKey();

--- a/server/src/main/java/io/druid/server/metrics/HistoricalMetricsMonitor.java
+++ b/server/src/main/java/io/druid/server/metrics/HistoricalMetricsMonitor.java
@@ -31,8 +31,8 @@ import io.druid.server.coordination.ZkCoordinator;
 import io.druid.timeline.DataSegment;
 import it.unimi.dsi.fastutil.objects.Object2LongMap;
 import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
-import it.unimi.dsi.fastutil.objects.ObjectIterator;
 
+import java.util.Iterator;
 import java.util.Map;
 
 public class HistoricalMetricsMonitor extends AbstractMonitor
@@ -64,10 +64,9 @@ public class HistoricalMetricsMonitor extends AbstractMonitor
       pendingDeleteSizes.addTo(segment.getDataSource(), segment.getSize());
     }
 
-    final ObjectIterator<Object2LongMap.Entry<String>> entries =
-        pendingDeleteSizes.object2LongEntrySet().fastIterator();
-
-    while (entries.hasNext()) {
+    for (final Iterator<Object2LongMap.Entry<String>> entries =
+         pendingDeleteSizes.object2LongEntrySet().fastIterator();
+         entries.hasNext();) {
       final Object2LongMap.Entry<String> entry = entries.next();
 
       final String dataSource = entry.getKey();

--- a/server/src/main/java/io/druid/server/metrics/HistoricalMetricsMonitor.java
+++ b/server/src/main/java/io/druid/server/metrics/HistoricalMetricsMonitor.java
@@ -24,7 +24,6 @@ import com.metamx.emitter.service.ServiceEmitter;
 import com.metamx.emitter.service.ServiceMetricEvent;
 import com.metamx.metrics.AbstractMonitor;
 import io.druid.client.DruidServerConfig;
-import io.druid.java.util.common.collect.CountingMap;
 import io.druid.query.DruidMetrics;
 import io.druid.server.coordination.ServerManager;
 import io.druid.server.coordination.ZkCoordinator;
@@ -70,7 +69,7 @@ public class HistoricalMetricsMonitor extends AbstractMonitor
       final Object2LongMap.Entry<String> entry = entries.next();
 
       final String dataSource = entry.getKey();
-      final long pendingDeleteSize = entry.getValue();
+      final long pendingDeleteSize = entry.getLongValue();
       emitter.emit(
           new ServiceMetricEvent.Builder()
               .setDimension(DruidMetrics.DATASOURCE, dataSource)

--- a/server/src/main/java/io/druid/server/metrics/HistoricalMetricsMonitor.java
+++ b/server/src/main/java/io/druid/server/metrics/HistoricalMetricsMonitor.java
@@ -31,9 +31,6 @@ import io.druid.timeline.DataSegment;
 import it.unimi.dsi.fastutil.objects.Object2LongMap;
 import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 public class HistoricalMetricsMonitor extends AbstractMonitor
 {
   private final DruidServerConfig serverConfig;

--- a/server/src/main/java/io/druid/server/metrics/HistoricalMetricsMonitor.java
+++ b/server/src/main/java/io/druid/server/metrics/HistoricalMetricsMonitor.java
@@ -31,7 +31,8 @@ import io.druid.timeline.DataSegment;
 import it.unimi.dsi.fastutil.objects.Object2LongMap;
 import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
 
-import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class HistoricalMetricsMonitor extends AbstractMonitor
 {
@@ -62,10 +63,7 @@ public class HistoricalMetricsMonitor extends AbstractMonitor
       pendingDeleteSizes.addTo(segment.getDataSource(), segment.getSize());
     }
 
-    for (final Iterator<Object2LongMap.Entry<String>> entries =
-         pendingDeleteSizes.object2LongEntrySet().fastIterator();
-         entries.hasNext(); ) {
-      final Object2LongMap.Entry<String> entry = entries.next();
+    for (final Object2LongMap.Entry<String> entry : pendingDeleteSizes.object2LongEntrySet()) {
 
       final String dataSource = entry.getKey();
       final long pendingDeleteSize = entry.getLongValue();
@@ -81,12 +79,10 @@ public class HistoricalMetricsMonitor extends AbstractMonitor
     serverManager.forEachDataSourceSize(
         (final String dataSource, final long used) -> {
           final ServiceMetricEvent.Builder builder =
-              new ServiceMetricEvent.Builder().setDimension(DruidMetrics.DATASOURCE, dataSource)
-                                              .setDimension("tier", serverConfig.getTier())
-                                              .setDimension(
-                                                  "priority",
-                                                  String.valueOf(serverConfig.getPriority())
-                                              );
+              new ServiceMetricEvent.Builder()
+                  .setDimension(DruidMetrics.DATASOURCE, dataSource)
+                  .setDimension("tier", serverConfig.getTier())
+                  .setDimension("priority", String.valueOf(serverConfig.getPriority()));
 
 
           emitter.emit(builder.build("segment/used", used));
@@ -100,12 +96,10 @@ public class HistoricalMetricsMonitor extends AbstractMonitor
     serverManager.forEachDataSourceCount(
         (final String dataSource, final long count) -> {
           final ServiceMetricEvent.Builder builder =
-              new ServiceMetricEvent.Builder().setDimension(DruidMetrics.DATASOURCE, dataSource)
-                                              .setDimension("tier", serverConfig.getTier())
-                                              .setDimension(
-                                                  "priority",
-                                                  String.valueOf(serverConfig.getPriority())
-                                              );
+              new ServiceMetricEvent.Builder()
+                  .setDimension(DruidMetrics.DATASOURCE, dataSource)
+                  .setDimension("tier", serverConfig.getTier())
+                  .setDimension("priority", String.valueOf(serverConfig.getPriority()));
 
           emitter.emit(builder.build("segment/count", count));
         }

--- a/server/src/main/java/io/druid/server/metrics/HistoricalMetricsMonitor.java
+++ b/server/src/main/java/io/druid/server/metrics/HistoricalMetricsMonitor.java
@@ -32,7 +32,6 @@ import it.unimi.dsi.fastutil.objects.Object2LongMap;
 import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
 
 import java.util.Iterator;
-import java.util.Map;
 
 public class HistoricalMetricsMonitor extends AbstractMonitor
 {
@@ -79,39 +78,38 @@ public class HistoricalMetricsMonitor extends AbstractMonitor
       );
     }
 
-    for (Map.Entry<String, Long> entry : serverManager.getDataSourceSizes().entrySet()) {
-      String dataSource = entry.getKey();
-      long used = entry.getValue();
-
-      final ServiceMetricEvent.Builder builder =
-          new ServiceMetricEvent.Builder().setDimension(DruidMetrics.DATASOURCE, dataSource)
-                                          .setDimension("tier", serverConfig.getTier())
-                                          .setDimension(
-                                              "priority",
-                                              String.valueOf(serverConfig.getPriority())
-                                          );
+    serverManager.forEachDataSourceSize(
+        (final String dataSource, final long used) -> {
+          final ServiceMetricEvent.Builder builder =
+              new ServiceMetricEvent.Builder().setDimension(DruidMetrics.DATASOURCE, dataSource)
+                                              .setDimension("tier", serverConfig.getTier())
+                                              .setDimension(
+                                                  "priority",
+                                                  String.valueOf(serverConfig.getPriority())
+                                              );
 
 
-      emitter.emit(builder.build("segment/used", used));
-      final double usedPercent = serverConfig.getMaxSize() == 0
-                                 ? 0
-                                 : used / (double) serverConfig.getMaxSize();
-      emitter.emit(builder.build("segment/usedPercent", usedPercent));
-    }
+          emitter.emit(builder.build("segment/used", used));
+          final double usedPercent = serverConfig.getMaxSize() == 0
+                                     ? 0
+                                     : used / (double) serverConfig.getMaxSize();
+          emitter.emit(builder.build("segment/usedPercent", usedPercent));
+        }
+    );
 
-    for (Map.Entry<String, Long> entry : serverManager.getDataSourceCounts().entrySet()) {
-      String dataSource = entry.getKey();
-      long count = entry.getValue();
-      final ServiceMetricEvent.Builder builder =
-          new ServiceMetricEvent.Builder().setDimension(DruidMetrics.DATASOURCE, dataSource)
-                                          .setDimension("tier", serverConfig.getTier())
-                                          .setDimension(
-                                              "priority",
-                                              String.valueOf(serverConfig.getPriority())
-                                          );
+    serverManager.forEachDataSourceCount(
+        (final String dataSource, final long count) -> {
+          final ServiceMetricEvent.Builder builder =
+              new ServiceMetricEvent.Builder().setDimension(DruidMetrics.DATASOURCE, dataSource)
+                                              .setDimension("tier", serverConfig.getTier())
+                                              .setDimension(
+                                                  "priority",
+                                                  String.valueOf(serverConfig.getPriority())
+                                              );
 
-      emitter.emit(builder.build("segment/count", count));
-    }
+          emitter.emit(builder.build("segment/count", count));
+        }
+    );
 
     return true;
   }

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerTest.java
@@ -202,8 +202,16 @@ public class DruidCoordinatorBalancerTest
             .build();
 
     params = new DruidCoordinatorBalancerTester(coordinator).run(params);
-    Assert.assertTrue(params.getCoordinatorStats().getTieredStat("movedCount", "normal") > 0);
-    Assert.assertTrue(params.getCoordinatorStats().getTieredStat("movedCount", "normal") < segments.size());
+
+    final long numMoved = params.getCoordinatorStats().getTieredStat("movedCount", "normal");
+
+    Assert.assertTrue(numMoved > 0);
+    Assert.assertTrue(numMoved <= segments.size());
+    Assert.assertEquals(numMoved,
+                        fromPeon.getSegmentsToLoad().size() +
+                        toPeon.getSegmentsToLoad().size());
+    Assert.assertTrue(toPeon.getSegmentsToLoad().size() > 0);
+    Assert.assertTrue(toPeon.getSegmentsToLoad().size() < segments.size());
     exec.shutdown();
   }
 

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerTest.java
@@ -202,9 +202,8 @@ public class DruidCoordinatorBalancerTest
             .build();
 
     params = new DruidCoordinatorBalancerTester(coordinator).run(params);
-    Assert.assertTrue(params.getCoordinatorStats().getPerTierStats().get("movedCount").getLong("normal") > 0);
-    Assert.assertTrue(params.getCoordinatorStats().getPerTierStats().get("movedCount").getLong("normal")
-                      < segments.size());
+    Assert.assertTrue(params.getCoordinatorStats().getTieredStat("movedCount", "normal") > 0);
+    Assert.assertTrue(params.getCoordinatorStats().getTieredStat("movedCount", "normal") < segments.size());
     exec.shutdown();
   }
 
@@ -262,7 +261,7 @@ public class DruidCoordinatorBalancerTest
             .build();
 
     params = new DruidCoordinatorBalancerTester(coordinator).run(params);
-    Assert.assertTrue(params.getCoordinatorStats().getPerTierStats().get("movedCount").getLong("normal") > 0);
+    Assert.assertTrue(params.getCoordinatorStats().getTieredStat("movedCount", "normal") > 0);
     exec.shutdown();
   }
 
@@ -325,7 +324,7 @@ public class DruidCoordinatorBalancerTest
             .build();
 
     params = new DruidCoordinatorBalancerTester(coordinator).run(params);
-    Assert.assertTrue(params.getCoordinatorStats().getPerTierStats().get("movedCount").getLong("normal") > 0);
+    Assert.assertTrue(params.getCoordinatorStats().getTieredStat("movedCount", "normal") > 0);
     exec.shutdown();
   }
 
@@ -393,8 +392,8 @@ public class DruidCoordinatorBalancerTest
 
     DruidCoordinatorBalancerTester balancerTester = new DruidCoordinatorBalancerTester(coordinator);
     params = balancerTester.run(params);
-    Assert.assertTrue(params.getCoordinatorStats().getPerTierStats().get("movedCount").getLong("normal") == 1);
-    Assert.assertTrue(params.getCoordinatorStats().getPerTierStats().get("movedCount").getLong("extra") == 1);
+    Assert.assertEquals(1L, params.getCoordinatorStats().getTieredStat("movedCount", "normal"));
+    Assert.assertEquals(1L, params.getCoordinatorStats().getTieredStat("movedCount", "extra"));
 
     exec.shutdown();
   }
@@ -454,7 +453,7 @@ public class DruidCoordinatorBalancerTest
 
     DruidCoordinatorBalancerTester balancerTester = new DruidCoordinatorBalancerTester(coordinator);
     params = balancerTester.run(params);
-    Assert.assertTrue(params.getCoordinatorStats().getPerTierStats().get("movedCount").getLong("normal") == 1);
+    Assert.assertEquals(1L, params.getCoordinatorStats().getTieredStat("movedCount", "normal"));
 
     params = params.buildFromExisting()
                    .withDynamicConfigs(
@@ -465,7 +464,7 @@ public class DruidCoordinatorBalancerTest
                    .build();
 
     params = balancerTester.run(params);
-    Assert.assertTrue(params.getCoordinatorStats().getPerTierStats().get("movedCount").getLong("normal") == 2);
+    Assert.assertEquals(2L, params.getCoordinatorStats().getTieredStat("movedCount", "normal"));
     exec.shutdown();
   }
 

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerTest.java
@@ -202,8 +202,8 @@ public class DruidCoordinatorBalancerTest
             .build();
 
     params = new DruidCoordinatorBalancerTester(coordinator).run(params);
-    Assert.assertTrue(params.getCoordinatorStats().getPerTierStats().get("movedCount").get("normal").get() > 0);
-    Assert.assertTrue(params.getCoordinatorStats().getPerTierStats().get("movedCount").get("normal").get()
+    Assert.assertTrue(params.getCoordinatorStats().getPerTierStats().get("movedCount").getLong("normal") > 0);
+    Assert.assertTrue(params.getCoordinatorStats().getPerTierStats().get("movedCount").getLong("normal")
                       < segments.size());
     exec.shutdown();
   }
@@ -262,7 +262,7 @@ public class DruidCoordinatorBalancerTest
             .build();
 
     params = new DruidCoordinatorBalancerTester(coordinator).run(params);
-    Assert.assertTrue(params.getCoordinatorStats().getPerTierStats().get("movedCount").get("normal").get() > 0);
+    Assert.assertTrue(params.getCoordinatorStats().getPerTierStats().get("movedCount").getLong("normal") > 0);
     exec.shutdown();
   }
 
@@ -393,8 +393,8 @@ public class DruidCoordinatorBalancerTest
 
     DruidCoordinatorBalancerTester balancerTester = new DruidCoordinatorBalancerTester(coordinator);
     params = balancerTester.run(params);
-    Assert.assertTrue(params.getCoordinatorStats().getPerTierStats().get("movedCount").get("normal").get() == 1);
-    Assert.assertTrue(params.getCoordinatorStats().getPerTierStats().get("movedCount").get("extra").get() == 1);
+    Assert.assertTrue(params.getCoordinatorStats().getPerTierStats().get("movedCount").getLong("normal") == 1);
+    Assert.assertTrue(params.getCoordinatorStats().getPerTierStats().get("movedCount").getLong("extra") == 1);
 
     exec.shutdown();
   }
@@ -454,7 +454,7 @@ public class DruidCoordinatorBalancerTest
 
     DruidCoordinatorBalancerTester balancerTester = new DruidCoordinatorBalancerTester(coordinator);
     params = balancerTester.run(params);
-    Assert.assertTrue(params.getCoordinatorStats().getPerTierStats().get("movedCount").get("normal").get() == 1);
+    Assert.assertTrue(params.getCoordinatorStats().getPerTierStats().get("movedCount").getLong("normal") == 1);
 
     params = params.buildFromExisting()
                    .withDynamicConfigs(
@@ -465,7 +465,7 @@ public class DruidCoordinatorBalancerTest
                    .build();
 
     params = balancerTester.run(params);
-    Assert.assertTrue(params.getCoordinatorStats().getPerTierStats().get("movedCount").get("normal").get() == 2);
+    Assert.assertTrue(params.getCoordinatorStats().getPerTierStats().get("movedCount").getLong("normal") == 2);
     exec.shutdown();
   }
 

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorBalancerTest.java
@@ -325,7 +325,7 @@ public class DruidCoordinatorBalancerTest
             .build();
 
     params = new DruidCoordinatorBalancerTester(coordinator).run(params);
-    Assert.assertTrue(params.getCoordinatorStats().getPerTierStats().get("movedCount").get("normal").get() > 0);
+    Assert.assertTrue(params.getCoordinatorStats().getPerTierStats().get("movedCount").getLong("normal") > 0);
     exec.shutdown();
   }
 

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorRuleRunnerTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorRuleRunnerTest.java
@@ -201,9 +201,9 @@ public class DruidCoordinatorRuleRunnerTest
     DruidCoordinatorRuntimeParams afterParams = ruleRunner.run(params);
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
-    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").get("hot").get() == 6);
-    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").get("normal").get() == 6);
-    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").get("cold").get() == 12);
+    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").getLong("hot") == 6);
+    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").getLong("normal") == 6);
+    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").getLong("cold") == 12);
     Assert.assertTrue(stats.getPerTierStats().get("unassignedCount") == null);
     Assert.assertTrue(stats.getPerTierStats().get("unassignedSize") == null);
 
@@ -302,8 +302,8 @@ public class DruidCoordinatorRuleRunnerTest
     DruidCoordinatorRuntimeParams afterParams = ruleRunner.run(params);
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
-    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").get("hot").get() == 12);
-    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").get("cold").get() == 18);
+    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").getLong("hot") == 12);
+    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").getLong("cold") == 18);
     Assert.assertTrue(stats.getPerTierStats().get("unassignedCount") == null);
     Assert.assertTrue(stats.getPerTierStats().get("unassignedSize") == null);
 
@@ -398,8 +398,8 @@ public class DruidCoordinatorRuleRunnerTest
     DruidCoordinatorRuntimeParams afterParams = ruleRunner.run(params);
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
-    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").get("hot").get() == 12);
-    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").get("normal").get() == 0);
+    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").getLong("hot") == 12);
+    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").getLong("normal") == 0);
     Assert.assertTrue(stats.getPerTierStats().get("unassignedCount") == null);
     Assert.assertTrue(stats.getPerTierStats().get("unassignedSize") == null);
 
@@ -595,7 +595,7 @@ public class DruidCoordinatorRuleRunnerTest
     DruidCoordinatorRuntimeParams afterParams = ruleRunner.run(params);
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
-    Assert.assertTrue(stats.getGlobalStats().get("deletedCount").get() == 12);
+    Assert.assertTrue(stats.getGlobalStats().getLong("deletedCount") == 12);
 
     exec.shutdown();
     EasyMock.verify(coordinator);
@@ -679,8 +679,8 @@ public class DruidCoordinatorRuleRunnerTest
     DruidCoordinatorRuntimeParams afterParams = ruleRunner.run(params);
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
-    Assert.assertTrue(stats.getPerTierStats().get("droppedCount").get("normal").get() == 1);
-    Assert.assertTrue(stats.getGlobalStats().get("deletedCount").get() == 12);
+    Assert.assertTrue(stats.getPerTierStats().get("droppedCount").getLong("normal") == 1);
+    Assert.assertTrue(stats.getGlobalStats().getLong("deletedCount") == 12);
 
     exec.shutdown();
     EasyMock.verify(mockPeon);
@@ -770,8 +770,8 @@ public class DruidCoordinatorRuleRunnerTest
     DruidCoordinatorRuntimeParams afterParams = ruleRunner.run(params);
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
-    Assert.assertTrue(stats.getPerTierStats().get("droppedCount").get("normal").get() == 1);
-    Assert.assertTrue(stats.getGlobalStats().get("deletedCount").get() == 12);
+    Assert.assertTrue(stats.getPerTierStats().get("droppedCount").getLong("normal") == 1);
+    Assert.assertTrue(stats.getGlobalStats().getLong("deletedCount") == 12);
 
     exec.shutdown();
     EasyMock.verify(mockPeon);
@@ -858,7 +858,7 @@ public class DruidCoordinatorRuleRunnerTest
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
     Assert.assertTrue(stats.getPerTierStats().get("droppedCount") == null);
-    Assert.assertTrue(stats.getGlobalStats().get("deletedCount").get() == 12);
+    Assert.assertTrue(stats.getGlobalStats().getLong("deletedCount") == 12);
 
     exec.shutdown();
     EasyMock.verify(mockPeon);
@@ -957,7 +957,7 @@ public class DruidCoordinatorRuleRunnerTest
     DruidCoordinatorRuntimeParams afterParams = ruleRunner.run(params);
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
-    Assert.assertTrue(stats.getPerTierStats().get("droppedCount").get("normal").get() == 1);
+    Assert.assertTrue(stats.getPerTierStats().get("droppedCount").getLong("normal") == 1);
 
     exec.shutdown();
     EasyMock.verify(mockPeon);
@@ -1037,7 +1037,7 @@ public class DruidCoordinatorRuleRunnerTest
     DruidCoordinatorRuntimeParams afterParams = ruleRunner.run(params);
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
-    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").get("hot").get() == 48);
+    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").getLong("hot") == 48);
     Assert.assertTrue(stats.getPerTierStats().get("unassignedCount") == null);
     Assert.assertTrue(stats.getPerTierStats().get("unassignedSize") == null);
 
@@ -1066,7 +1066,7 @@ public class DruidCoordinatorRuleRunnerTest
     );
     stats = afterParams.getCoordinatorStats();
 
-    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").get("hot").get() == 1);
+    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").getLong("hot") == 1);
     Assert.assertTrue(stats.getPerTierStats().get("unassignedCount") == null);
     Assert.assertTrue(stats.getPerTierStats().get("unassignedSize") == null);
 
@@ -1167,8 +1167,8 @@ public class DruidCoordinatorRuleRunnerTest
     DruidCoordinatorRuntimeParams afterParams = runner.run(params);
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
-    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").get("hot").get() == 24);
-    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").get(DruidServer.DEFAULT_TIER).get() == 7);
+    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").getLong("hot") == 24);
+    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").getLong(DruidServer.DEFAULT_TIER) == 7);
     Assert.assertTrue(stats.getPerTierStats().get("unassignedCount") == null);
     Assert.assertTrue(stats.getPerTierStats().get("unassignedSize") == null);
 
@@ -1269,7 +1269,7 @@ public class DruidCoordinatorRuleRunnerTest
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
     // There is no throttling on drop
-    Assert.assertTrue(stats.getPerTierStats().get("droppedCount").get("normal").get() == 25);
+    Assert.assertTrue(stats.getPerTierStats().get("droppedCount").getLong("normal") == 25);
     EasyMock.verify(mockPeon);
     exec.shutdown();
   }

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorRuleRunnerTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorRuleRunnerTest.java
@@ -201,11 +201,11 @@ public class DruidCoordinatorRuleRunnerTest
     DruidCoordinatorRuntimeParams afterParams = ruleRunner.run(params);
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
-    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").getLong("hot") == 6);
-    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").getLong("normal") == 6);
-    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").getLong("cold") == 12);
-    Assert.assertTrue(stats.getPerTierStats().get("unassignedCount") == null);
-    Assert.assertTrue(stats.getPerTierStats().get("unassignedSize") == null);
+    Assert.assertEquals(6L, stats.getTieredStat("assignedCount", "hot"));
+    Assert.assertEquals(6L, stats.getTieredStat("assignedCount", "normal"));
+    Assert.assertEquals(12L, stats.getTieredStat("assignedCount", "cold"));
+    Assert.assertTrue(stats.getTiers("unassignedCount").isEmpty());
+    Assert.assertTrue(stats.getTiers("unassignedSize").isEmpty());
 
     exec.shutdown();
     EasyMock.verify(mockPeon);
@@ -302,10 +302,10 @@ public class DruidCoordinatorRuleRunnerTest
     DruidCoordinatorRuntimeParams afterParams = ruleRunner.run(params);
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
-    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").getLong("hot") == 12);
-    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").getLong("cold") == 18);
-    Assert.assertTrue(stats.getPerTierStats().get("unassignedCount") == null);
-    Assert.assertTrue(stats.getPerTierStats().get("unassignedSize") == null);
+    Assert.assertEquals(12L, stats.getTieredStat("assignedCount", "hot"));
+    Assert.assertEquals(18L, stats.getTieredStat("assignedCount", "cold"));
+    Assert.assertTrue(stats.getTiers("unassignedCount").isEmpty());
+    Assert.assertTrue(stats.getTiers("unassignedSize").isEmpty());
 
     exec.shutdown();
     EasyMock.verify(mockPeon);
@@ -398,10 +398,10 @@ public class DruidCoordinatorRuleRunnerTest
     DruidCoordinatorRuntimeParams afterParams = ruleRunner.run(params);
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
-    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").getLong("hot") == 12);
-    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").getLong("normal") == 0);
-    Assert.assertTrue(stats.getPerTierStats().get("unassignedCount") == null);
-    Assert.assertTrue(stats.getPerTierStats().get("unassignedSize") == null);
+    Assert.assertEquals(12L, stats.getTieredStat("assignedCount", "hot"));
+    Assert.assertEquals(0L, stats.getTieredStat("assignedCount", "normal"));
+    Assert.assertTrue(stats.getTiers("unassignedCount").isEmpty());
+    Assert.assertTrue(stats.getTiers("unassignedSize").isEmpty());
 
     exec.shutdown();
     EasyMock.verify(mockPeon);
@@ -595,7 +595,7 @@ public class DruidCoordinatorRuleRunnerTest
     DruidCoordinatorRuntimeParams afterParams = ruleRunner.run(params);
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
-    Assert.assertTrue(stats.getGlobalStats().getLong("deletedCount") == 12);
+    Assert.assertEquals(12L, stats.getGlobalStat("deletedCount"));
 
     exec.shutdown();
     EasyMock.verify(coordinator);
@@ -679,8 +679,8 @@ public class DruidCoordinatorRuleRunnerTest
     DruidCoordinatorRuntimeParams afterParams = ruleRunner.run(params);
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
-    Assert.assertTrue(stats.getPerTierStats().get("droppedCount").getLong("normal") == 1);
-    Assert.assertTrue(stats.getGlobalStats().getLong("deletedCount") == 12);
+    Assert.assertEquals(1L, stats.getTieredStat("droppedCount", "normal"));
+    Assert.assertEquals(12L, stats.getGlobalStat("deletedCount"));
 
     exec.shutdown();
     EasyMock.verify(mockPeon);
@@ -770,8 +770,8 @@ public class DruidCoordinatorRuleRunnerTest
     DruidCoordinatorRuntimeParams afterParams = ruleRunner.run(params);
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
-    Assert.assertTrue(stats.getPerTierStats().get("droppedCount").getLong("normal") == 1);
-    Assert.assertTrue(stats.getGlobalStats().getLong("deletedCount") == 12);
+    Assert.assertEquals(1L, stats.getTieredStat("droppedCount", "normal"));
+    Assert.assertEquals(12L, stats.getGlobalStat("deletedCount"));
 
     exec.shutdown();
     EasyMock.verify(mockPeon);
@@ -857,8 +857,8 @@ public class DruidCoordinatorRuleRunnerTest
     DruidCoordinatorRuntimeParams afterParams = ruleRunner.run(params);
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
-    Assert.assertTrue(stats.getPerTierStats().get("droppedCount") == null);
-    Assert.assertTrue(stats.getGlobalStats().getLong("deletedCount") == 12);
+    Assert.assertTrue(stats.getTiers("droppedCount").isEmpty());
+    Assert.assertEquals(12L, stats.getGlobalStat("deletedCount"));
 
     exec.shutdown();
     EasyMock.verify(mockPeon);
@@ -957,7 +957,7 @@ public class DruidCoordinatorRuleRunnerTest
     DruidCoordinatorRuntimeParams afterParams = ruleRunner.run(params);
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
-    Assert.assertTrue(stats.getPerTierStats().get("droppedCount").getLong("normal") == 1);
+    Assert.assertEquals(1L, stats.getTieredStat("droppedCount", "normal"));
 
     exec.shutdown();
     EasyMock.verify(mockPeon);
@@ -1037,9 +1037,9 @@ public class DruidCoordinatorRuleRunnerTest
     DruidCoordinatorRuntimeParams afterParams = ruleRunner.run(params);
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
-    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").getLong("hot") == 48);
-    Assert.assertTrue(stats.getPerTierStats().get("unassignedCount") == null);
-    Assert.assertTrue(stats.getPerTierStats().get("unassignedSize") == null);
+    Assert.assertEquals(48L, stats.getTieredStat("assignedCount", "hot"));
+    Assert.assertTrue(stats.getTiers("unassignedCount").isEmpty());
+    Assert.assertTrue(stats.getTiers("unassignedSize").isEmpty());
 
     DataSegment overFlowSegment = new DataSegment(
         "test",
@@ -1066,9 +1066,9 @@ public class DruidCoordinatorRuleRunnerTest
     );
     stats = afterParams.getCoordinatorStats();
 
-    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").getLong("hot") == 1);
-    Assert.assertTrue(stats.getPerTierStats().get("unassignedCount") == null);
-    Assert.assertTrue(stats.getPerTierStats().get("unassignedSize") == null);
+    Assert.assertEquals(1L, stats.getTieredStat("assignedCount", "hot"));
+    Assert.assertTrue(stats.getTiers("unassignedCount").isEmpty());
+    Assert.assertTrue(stats.getTiers("unassignedSize").isEmpty());
 
     EasyMock.verify(mockPeon);
     exec.shutdown();
@@ -1167,10 +1167,10 @@ public class DruidCoordinatorRuleRunnerTest
     DruidCoordinatorRuntimeParams afterParams = runner.run(params);
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
-    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").getLong("hot") == 24);
-    Assert.assertTrue(stats.getPerTierStats().get("assignedCount").getLong(DruidServer.DEFAULT_TIER) == 7);
-    Assert.assertTrue(stats.getPerTierStats().get("unassignedCount") == null);
-    Assert.assertTrue(stats.getPerTierStats().get("unassignedSize") == null);
+    Assert.assertEquals(24L, stats.getTieredStat("assignedCount", "hot"));
+    Assert.assertEquals(7L, stats.getTieredStat("assignedCount", DruidServer.DEFAULT_TIER));
+    Assert.assertTrue(stats.getTiers("unassignedCount").isEmpty());
+    Assert.assertTrue(stats.getTiers("unassignedSize").isEmpty());
 
     EasyMock.verify(mockPeon);
     exec.shutdown();
@@ -1269,7 +1269,7 @@ public class DruidCoordinatorRuleRunnerTest
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
     // There is no throttling on drop
-    Assert.assertTrue(stats.getPerTierStats().get("droppedCount").getLong("normal") == 25);
+    Assert.assertEquals(25L, stats.getTieredStat("droppedCount", "normal"));
     EasyMock.verify(mockPeon);
     exec.shutdown();
   }
@@ -1356,10 +1356,10 @@ public class DruidCoordinatorRuleRunnerTest
     DruidCoordinatorRuntimeParams afterParams = ruleRunner.run(params);
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
-    Assert.assertEquals(1, stats.getPerTierStats().get("assignedCount").size());
-    Assert.assertEquals(1, stats.getPerTierStats().get("assignedCount").getLong("_default_tier"));
-    Assert.assertNull(stats.getPerTierStats().get("unassignedCount"));
-    Assert.assertNull(stats.getPerTierStats().get("unassignedSize"));
+    Assert.assertEquals(1, stats.getTiers("assignedCount").size());
+    Assert.assertEquals(1, stats.getTieredStat("assignedCount", "_default_tier"));
+    Assert.assertTrue(stats.getTiers("unassignedCount").isEmpty());
+    Assert.assertTrue(stats.getTiers("unassignedSize").isEmpty());
 
     Assert.assertEquals(2, availableSegments.size());
     Assert.assertEquals(availableSegments, params.getAvailableSegments());

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorRuleRunnerTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorRuleRunnerTest.java
@@ -1357,7 +1357,7 @@ public class DruidCoordinatorRuleRunnerTest
     CoordinatorStats stats = afterParams.getCoordinatorStats();
 
     Assert.assertEquals(1, stats.getPerTierStats().get("assignedCount").size());
-    Assert.assertEquals(1, stats.getPerTierStats().get("assignedCount").get("_default_tier").get());
+    Assert.assertEquals(1, stats.getPerTierStats().get("assignedCount").getLong("_default_tier"));
     Assert.assertNull(stats.getPerTierStats().get("unassignedCount"));
     Assert.assertNull(stats.getPerTierStats().get("unassignedSize"));
 

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorTest.java
@@ -31,7 +31,6 @@ import io.druid.client.DruidServer;
 import io.druid.client.ImmutableDruidDataSource;
 import io.druid.client.ImmutableDruidServer;
 import io.druid.client.SingleServerInventoryView;
-import io.druid.collections.CountingMap;
 import io.druid.common.config.JacksonConfigManager;
 import io.druid.concurrent.Execs;
 import io.druid.curator.CuratorTestBase;
@@ -49,6 +48,7 @@ import io.druid.server.initialization.ZkPathsConfig;
 import io.druid.server.lookup.cache.LookupCoordinatorManager;
 import io.druid.server.metrics.NoopServiceEmitter;
 import io.druid.timeline.DataSegment;
+import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.cache.PathChildrenCache;
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
@@ -346,14 +346,14 @@ public class DruidCoordinatorTest extends CuratorTestBase
     Assert.assertEquals(ImmutableMap.of(dataSource, 100.0), coordinator.getLoadStatus());
     curator.delete().guaranteed().forPath(ZKPaths.makePath(LOADPATH, dataSegment.getIdentifier()));
     // Wait for coordinator thread to run so that replication status is updated
-    while (coordinator.getSegmentAvailability().snapshot().get(dataSource) != 0) {
+    while (coordinator.getSegmentAvailability().getLong(dataSource) != 0) {
       Thread.sleep(50);
     }
-    Map segmentAvailability = coordinator.getSegmentAvailability().snapshot();
+    Map segmentAvailability = coordinator.getSegmentAvailability();
     Assert.assertEquals(1, segmentAvailability.size());
     Assert.assertEquals(0L, segmentAvailability.get(dataSource));
 
-    while (coordinator.getLoadPendingDatasources().get(dataSource).get() > 0) {
+    while (coordinator.getLoadPendingDatasources().getLong(dataSource) > 0) {
       Thread.sleep(50);
     }
 
@@ -364,17 +364,18 @@ public class DruidCoordinatorTest extends CuratorTestBase
       Thread.sleep(100);
     }
 
-    Map<String, CountingMap<String>> replicationStatus = coordinator.getReplicationStatus();
+    Map<String, Object2LongOpenHashMap<String>> replicationStatus =
+        coordinator.getReplicationStatus();
     Assert.assertNotNull(replicationStatus);
     Assert.assertEquals(1, replicationStatus.entrySet().size());
 
-    CountingMap<String> dataSourceMap = replicationStatus.get(tier);
+    Object2LongOpenHashMap<String> dataSourceMap = replicationStatus.get(tier);
     Assert.assertNotNull(dataSourceMap);
     Assert.assertEquals(1, dataSourceMap.size());
     Assert.assertNotNull(dataSourceMap.get(dataSource));
     // Simulated the adding of segment to druidServer during SegmentChangeRequestLoad event
     // The load rules asks for 2 replicas, therefore 1 replica should still be pending
-    Assert.assertEquals(1L, dataSourceMap.get(dataSource).get());
+    Assert.assertEquals(1L, dataSourceMap.getLong(dataSource));
 
     coordinator.stop();
     leaderUnannouncerLatch.await();

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorTest.java
@@ -48,6 +48,7 @@ import io.druid.server.initialization.ZkPathsConfig;
 import io.druid.server.lookup.cache.LookupCoordinatorManager;
 import io.druid.server.metrics.NoopServiceEmitter;
 import io.druid.timeline.DataSegment;
+import it.unimi.dsi.fastutil.objects.Object2LongMap;
 import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.cache.PathChildrenCache;
@@ -353,7 +354,7 @@ public class DruidCoordinatorTest extends CuratorTestBase
     Assert.assertEquals(1, segmentAvailability.size());
     Assert.assertEquals(0L, segmentAvailability.get(dataSource));
 
-    while (coordinator.getLoadPendingDatasources().getLong(dataSource) > 0) {
+    while (coordinator.hasLoadPending(dataSource)) {
       Thread.sleep(50);
     }
 
@@ -364,12 +365,12 @@ public class DruidCoordinatorTest extends CuratorTestBase
       Thread.sleep(100);
     }
 
-    Map<String, Object2LongOpenHashMap<String>> replicationStatus =
+    Map<String, ? extends Object2LongMap<String>> replicationStatus =
         coordinator.getReplicationStatus();
     Assert.assertNotNull(replicationStatus);
     Assert.assertEquals(1, replicationStatus.entrySet().size());
 
-    Object2LongOpenHashMap<String> dataSourceMap = replicationStatus.get(tier);
+    Object2LongMap<String> dataSourceMap = replicationStatus.get(tier);
     Assert.assertNotNull(dataSourceMap);
     Assert.assertEquals(1, dataSourceMap.size());
     Assert.assertNotNull(dataSourceMap.get(dataSource));

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorTest.java
@@ -49,7 +49,6 @@ import io.druid.server.lookup.cache.LookupCoordinatorManager;
 import io.druid.server.metrics.NoopServiceEmitter;
 import io.druid.timeline.DataSegment;
 import it.unimi.dsi.fastutil.objects.Object2LongMap;
-import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.cache.PathChildrenCache;
 import org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;

--- a/server/src/test/java/io/druid/server/coordinator/rules/BroadcastDistributionRuleTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/rules/BroadcastDistributionRuleTest.java
@@ -231,8 +231,8 @@ public class BroadcastDistributionRuleTest
         smallSegment
     );
 
-    assertEquals(3, stats.getGlobalStats().get(LoadRule.ASSIGNED_COUNT).intValue());
-    assertTrue(stats.getPerTierStats().isEmpty());
+    assertEquals(3L, stats.getGlobalStat(LoadRule.ASSIGNED_COUNT));
+    assertFalse(stats.hasPerTierStats());
 
     assertTrue(
         holdersOfLargeSegments.stream()
@@ -271,8 +271,8 @@ public class BroadcastDistributionRuleTest
         smallSegment
     );
 
-    assertEquals(5, stats.getGlobalStats().get(LoadRule.ASSIGNED_COUNT).intValue());
-    assertTrue(stats.getPerTierStats().isEmpty());
+    assertEquals(5L, stats.getGlobalStat(LoadRule.ASSIGNED_COUNT));
+    assertFalse(stats.hasPerTierStats());
 
     assertTrue(
         holdersOfLargeSegments.stream()
@@ -309,8 +309,8 @@ public class BroadcastDistributionRuleTest
         smallSegment
     );
 
-    assertEquals(6, stats.getGlobalStats().get(LoadRule.ASSIGNED_COUNT).intValue());
-    assertTrue(stats.getPerTierStats().isEmpty());
+    assertEquals(6L, stats.getGlobalStat(LoadRule.ASSIGNED_COUNT));
+    assertFalse(stats.hasPerTierStats());
 
     assertTrue(
         druidCluster.getAllServers().stream()

--- a/server/src/test/java/io/druid/server/coordinator/rules/LoadRuleTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/rules/LoadRuleTest.java
@@ -211,8 +211,8 @@ public class LoadRuleTest
         segment
     );
 
-    Assert.assertTrue(stats.getPerTierStats().get(LoadRule.ASSIGNED_COUNT).getLong("hot") == 1);
-    Assert.assertTrue(stats.getPerTierStats().get(LoadRule.ASSIGNED_COUNT).getLong(DruidServer.DEFAULT_TIER) == 2);
+    Assert.assertEquals(1L, stats.getTieredStat(LoadRule.ASSIGNED_COUNT, "hot"));
+    Assert.assertEquals(2L, stats.getTieredStat(LoadRule.ASSIGNED_COUNT, DruidServer.DEFAULT_TIER));
     exec.shutdown();
   }
 
@@ -321,8 +321,8 @@ public class LoadRuleTest
         segment
     );
 
-    Assert.assertTrue(stats.getPerTierStats().get("droppedCount").getLong("hot") == 1);
-    Assert.assertTrue(stats.getPerTierStats().get("droppedCount").getLong(DruidServer.DEFAULT_TIER) == 1);
+    Assert.assertEquals(1L, stats.getTieredStat("droppedCount", "hot"));
+    Assert.assertEquals(1L, stats.getTieredStat("droppedCount", DruidServer.DEFAULT_TIER));
     exec.shutdown();
   }
 
@@ -411,7 +411,7 @@ public class LoadRuleTest
         segment
     );
 
-    Assert.assertTrue(stats.getPerTierStats().get(LoadRule.ASSIGNED_COUNT).getLong("hot") == 1);
+    Assert.assertEquals(1L, stats.getTieredStat(LoadRule.ASSIGNED_COUNT, "hot"));
     exec.shutdown();
   }
 
@@ -516,7 +516,7 @@ public class LoadRuleTest
         segment
     );
 
-    Assert.assertTrue(stats.getPerTierStats().get("droppedCount").getLong("hot") == 1);
+    Assert.assertEquals(1L, stats.getTieredStat("droppedCount", "hot"));
     exec.shutdown();
   }
 }

--- a/server/src/test/java/io/druid/server/coordinator/rules/LoadRuleTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/rules/LoadRuleTest.java
@@ -211,8 +211,8 @@ public class LoadRuleTest
         segment
     );
 
-    Assert.assertTrue(stats.getPerTierStats().get(LoadRule.ASSIGNED_COUNT).get("hot").get() == 1);
-    Assert.assertTrue(stats.getPerTierStats().get(LoadRule.ASSIGNED_COUNT).get(DruidServer.DEFAULT_TIER).get() == 2);
+    Assert.assertTrue(stats.getPerTierStats().get(LoadRule.ASSIGNED_COUNT).getLong("hot") == 1);
+    Assert.assertTrue(stats.getPerTierStats().get(LoadRule.ASSIGNED_COUNT).getLong(DruidServer.DEFAULT_TIER) == 2);
     exec.shutdown();
   }
 
@@ -321,8 +321,8 @@ public class LoadRuleTest
         segment
     );
 
-    Assert.assertTrue(stats.getPerTierStats().get("droppedCount").get("hot").get() == 1);
-    Assert.assertTrue(stats.getPerTierStats().get("droppedCount").get(DruidServer.DEFAULT_TIER).get() == 1);
+    Assert.assertTrue(stats.getPerTierStats().get("droppedCount").getLong("hot") == 1);
+    Assert.assertTrue(stats.getPerTierStats().get("droppedCount").getLong(DruidServer.DEFAULT_TIER) == 1);
     exec.shutdown();
   }
 
@@ -411,7 +411,7 @@ public class LoadRuleTest
         segment
     );
 
-    Assert.assertTrue(stats.getPerTierStats().get(LoadRule.ASSIGNED_COUNT).get("hot").get() == 1);
+    Assert.assertTrue(stats.getPerTierStats().get(LoadRule.ASSIGNED_COUNT).getLong("hot") == 1);
     exec.shutdown();
   }
 
@@ -516,7 +516,7 @@ public class LoadRuleTest
         segment
     );
 
-    Assert.assertTrue(stats.getPerTierStats().get("droppedCount").get("hot").get() == 1);
+    Assert.assertTrue(stats.getPerTierStats().get("droppedCount").getLong("hot") == 1);
     exec.shutdown();
   }
 }

--- a/server/src/test/java/io/druid/server/metrics/HistoricalMetricsMonitorTest.java
+++ b/server/src/test/java/io/druid/server/metrics/HistoricalMetricsMonitorTest.java
@@ -22,6 +22,7 @@ package io.druid.server.metrics;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.metamx.emitter.service.ServiceEmitter;
 import com.metamx.emitter.service.ServiceEventBuilder;
@@ -165,5 +166,218 @@ public class HistoricalMetricsMonitorTest extends EasyMockSupport
         "priority", String.valueOf(priority),
         "dataSource", dataSource
     ), events.get(4));
+  }
+
+  @Test
+  public void testPendingDeleteSizeCounts()
+  {
+    final DataSegment segment1 = new DataSegment(
+        "dataSource1",
+        Interval.parse("2014/2015"),
+        "version",
+        ImmutableMap.<String, Object>of(),
+        ImmutableList.<String>of(),
+        ImmutableList.<String>of(),
+        null,
+        1,
+        13
+    );
+
+    final DataSegment segment2 = new DataSegment(
+        "dataSource2",
+        Interval.parse("2014/2015"),
+        "version",
+        ImmutableMap.<String, Object>of(),
+        ImmutableList.<String>of(),
+        ImmutableList.<String>of(),
+        null,
+        1,
+        47
+    );
+
+    final DataSegment segment3 = new DataSegment(
+        "dataSource1",
+        Interval.parse("2014/2015"),
+        "version",
+        ImmutableMap.<String, Object>of(),
+        ImmutableList.<String>of(),
+        ImmutableList.<String>of(),
+        null,
+        1,
+        17
+    );
+
+    final long size1 = segment1.getSize() + segment3.getSize();
+    final long size2 = segment2.getSize();
+
+    final List<DataSegment> dataSegments = ImmutableList.of(segment1, segment2, segment3);
+
+    final long maxSize = 64L;
+    final int priority = 0;
+    final String tier = "some_tier";
+
+    EasyMock.expect(druidServerConfig.getMaxSize()).andReturn(maxSize).once();
+    EasyMock.expect(zkCoordinator.getPendingDeleteSnapshot()).andReturn(dataSegments).once();
+
+    EasyMock.expect(druidServerConfig.getTier()).andReturn(tier).once();
+    EasyMock.expect(druidServerConfig.getPriority()).andReturn(priority).once();
+
+    EasyMock.expect(druidServerConfig.getTier()).andReturn(tier).once();
+    EasyMock.expect(druidServerConfig.getPriority()).andReturn(priority).once();
+
+    EasyMock
+        .expect(serverManager.getDataSourceSizes())
+        .andReturn(
+            ImmutableMap.of(
+                segment1.getDataSource(), size1,
+                segment2.getDataSource(), size2
+            )
+        ).once();
+
+    EasyMock.expect(druidServerConfig.getTier()).andReturn(tier).once();
+    EasyMock.expect(druidServerConfig.getPriority()).andReturn(priority).once();
+    EasyMock.expect(druidServerConfig.getMaxSize()).andReturn(maxSize).times(2);
+
+    EasyMock.expect(druidServerConfig.getTier()).andReturn(tier).once();
+    EasyMock.expect(druidServerConfig.getPriority()).andReturn(priority).once();
+    EasyMock.expect(druidServerConfig.getMaxSize()).andReturn(maxSize).times(2);
+
+    EasyMock
+        .expect(serverManager.getDataSourceCounts())
+        .andReturn(
+            ImmutableMap.of(
+                segment1.getDataSource(), 2L,
+                segment2.getDataSource(), 1L
+            )
+        ).once();
+
+    EasyMock.expect(druidServerConfig.getTier()).andReturn(tier).once();
+    EasyMock.expect(druidServerConfig.getPriority()).andReturn(priority).once();
+
+    EasyMock.expect(druidServerConfig.getTier()).andReturn(tier).once();
+    EasyMock.expect(druidServerConfig.getPriority()).andReturn(priority).once();
+
+    final HistoricalMetricsMonitor monitor = new HistoricalMetricsMonitor(
+        druidServerConfig,
+        serverManager,
+        zkCoordinator
+    );
+
+    final Capture<ServiceEventBuilder<ServiceMetricEvent>> eventCapture =
+        EasyMock.newCapture(CaptureType.ALL);
+    serviceEmitter.emit(EasyMock.capture(eventCapture));
+    EasyMock.expectLastCall().times(9);
+
+    EasyMock.replay(druidServerConfig, serverManager, zkCoordinator, serviceEmitter);
+    monitor.doMonitor(serviceEmitter);
+    //EasyMock.verify(druidServerConfig, serverManager, zkCoordinator, serviceEmitter);
+
+    Assert.assertTrue(eventCapture.hasCaptured());
+    final List<Map<String, Object>> events = Lists.transform(
+        eventCapture.getValues(),
+        new Function<ServiceEventBuilder<ServiceMetricEvent>, Map<String, Object>>()
+        {
+          @Nullable
+          @Override
+          public Map<String, Object> apply(
+              @Nullable ServiceEventBuilder<ServiceMetricEvent> input
+          )
+          {
+            final HashMap<String, Object> map =
+                new HashMap<>(input.build("host", "service").toMap());
+            Assert.assertNotNull(map.remove("feed"));
+            Assert.assertNotNull(map.remove("timestamp"));
+            Assert.assertNotNull(map.remove("service"));
+            Assert.assertNotNull(map.remove("host"));
+            return map;
+          }
+        }
+    );
+
+    Assert.assertEquals(ImmutableMap.<String, Object>of(
+        "metric", "segment/max",
+        "value", maxSize
+    ), events.get(0));
+
+    Assert.assertEquals(
+        ImmutableSet.of(
+            ImmutableMap.<String, Object>of(
+                "dataSource", segment1.getDataSource(),
+                "metric", "segment/pendingDelete",
+                "priority", String.valueOf(priority),
+                "tier", tier,
+                "value", size1
+            ),
+            ImmutableMap.<String, Object>of(
+                "dataSource", segment2.getDataSource(),
+                "metric", "segment/pendingDelete",
+                "priority", String.valueOf(priority),
+                "tier", tier,
+                "value", size2
+            )
+        ),
+        ImmutableSet.of(events.get(1), events.get(2))
+    );
+
+    Assert.assertEquals(
+        ImmutableSet.of(
+            ImmutableMap.<String, Object>of(
+                "metric", "segment/used",
+                "value", size1,
+                "tier", tier,
+                "priority", String.valueOf(priority),
+                "dataSource", segment1.getDataSource()
+            ),
+            ImmutableMap.<String, Object>of(
+                "metric", "segment/used",
+                "value", size2,
+                "tier", tier,
+                "priority", String.valueOf(priority),
+                "dataSource", segment2.getDataSource()
+            )
+        ),
+        ImmutableSet.of(events.get(3), events.get(5))
+    );
+
+    Assert.assertEquals(
+        ImmutableSet.of(
+            ImmutableMap.<String, Object>of(
+                "metric", "segment/usedPercent",
+                "value",  size1 * 1.0D / maxSize,
+                "tier", tier,
+                "priority", String.valueOf(priority),
+                "dataSource", segment1.getDataSource()
+            ),
+            ImmutableMap.<String, Object>of(
+                "metric", "segment/usedPercent",
+                "value",  size2 * 1.0D / maxSize,
+                "tier", tier,
+                "priority", String.valueOf(priority),
+                "dataSource", segment2.getDataSource()
+            )
+        ),
+        ImmutableSet.of(events.get(4), events.get(6))
+    );
+
+    Assert.assertEquals(
+        ImmutableSet.of(
+            ImmutableMap.<String, Object>of(
+                "metric", "segment/count",
+                "value", 2L,
+                "tier", tier,
+                "priority", String.valueOf(priority),
+                "dataSource", segment1.getDataSource()
+            ),
+            ImmutableMap.<String, Object>of(
+                "metric", "segment/count",
+                "value", 1L,
+                "tier", tier,
+                "priority", String.valueOf(priority),
+                "dataSource", segment2.getDataSource()
+            )
+        ),
+        ImmutableSet.of(events.get(7), events.get(8))
+    );
+
   }
 }


### PR DESCRIPTION
This replaces the use of `CountingMap`s (i.e., `com.metamx.common.collect.CountingMap` and `io.druid.collection.CountingMap`) with `Object2LongMap` (i.e., `Object2LongOpenHashMap`).

Concerning concurrent semantics of the `AtomicLong` used in `CountingMap`:
- `HistoicalMetricsMonitor`, `DatasourceInputFormat` and `DruidCoordinatorLogger` use `CountingMap` internally within a method call.
- Uses in `ServerManager` are already wrapped in a synchronized blocks.
- `DruidCoordinator` returns newly constructed instances of `CountingMap`s, which are consumed immediately by the caller.
- `CoordinatorStats` also returns `CountingMap` but there is no evidence that atomicity is a requirement since it also uses vanilla `HashMap`