### PR TITLE
[BACKEND-935] Priority on loading for primary replica

### DIFF
--- a/server/src/main/java/io/druid/server/coordinator/rules/LoadRule.java
+++ b/server/src/main/java/io/druid/server/coordinator/rules/LoadRule.java
@@ -22,10 +22,12 @@ package io.druid.server.coordinator.rules;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.MinMaxPriorityQueue;
+import com.google.common.primitives.Ints;
 import com.metamx.emitter.EmittingLogger;
 import io.druid.java.util.common.IAE;
 import io.druid.server.coordinator.BalancerStrategy;
 import io.druid.server.coordinator.CoordinatorStats;
+import io.druid.server.coordinator.DruidCluster;
 import io.druid.server.coordinator.DruidCoordinator;
 import io.druid.server.coordinator.DruidCoordinatorRuntimeParams;
 import io.druid.server.coordinator.LoadPeonCallback;
@@ -36,6 +38,7 @@ import io.druid.timeline.DataSegment;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -57,12 +60,56 @@ public abstract class LoadRule implements Rule
 
     final Map<String, Integer> loadStatus = Maps.newHashMap();
 
+    final Map<String, Integer> tieredReplicants = getTieredReplicants();
+    for (final String tier : tieredReplicants.keySet()) {
+      stats.addToTieredStat(ASSIGNED_COUNT, tier, 0);
+    }
+
+    final BalancerStrategy strategy = params.getBalancerStrategy();
+
+    final int maxSegmentsInNodeLoadingQueue = params.getCoordinatorDynamicConfig()
+                                                    .getMaxSegmentsInNodeLoadingQueue();
+
+    final Predicate<ServerHolder> serverHolderPredicate;
+    if (maxSegmentsInNodeLoadingQueue > 0) {
+      serverHolderPredicate = s -> (s != null && s.getNumberOfSegmentsInQueue() < maxSegmentsInNodeLoadingQueue);
+    } else {
+      serverHolderPredicate = Objects::nonNull;
+    }
+
     int totalReplicantsInCluster = params.getSegmentReplicantLookup().getTotalReplicants(segment.getIdentifier());
-    for (Map.Entry<String, Integer> entry : getTieredReplicants().entrySet()) {
+
+    final Optional<String> primaryLoadingTier;
+    if (totalReplicantsInCluster <= 0) {
+      final Optional<ServerHolder> primaryHolderToLoad = getPrimaryHolder(
+          params.getDruidCluster(),
+          tieredReplicants,
+          strategy,
+          segment,
+          serverHolderPredicate
+      );
+
+      if (primaryHolderToLoad.isPresent()) {
+        final ServerHolder holder = primaryHolderToLoad.get();
+
+        primaryLoadingTier = Optional.of(holder.getServer().getTier());
+
+        holder.getPeon().loadSegment(segment, null);
+        stats.addToTieredStat(ASSIGNED_COUNT, holder.getServer().getTier(), 1);
+        ++totalReplicantsInCluster;
+      } else {
+        return stats;
+      }
+    } else {
+      primaryLoadingTier = Optional.empty();
+    }
+
+    for (Map.Entry<String, Integer> entry : tieredReplicants.entrySet()) {
       final String tier = entry.getKey();
       final int expectedReplicantsInTier = entry.getValue();
       final int totalReplicantsInTier = params.getSegmentReplicantLookup()
-                                              .getTotalReplicants(segment.getIdentifier(), tier);
+                                              .getTotalReplicants(segment.getIdentifier(), tier) +
+                                        (primaryLoadingTier.map(tier::equals).orElse(false) ? 1 : 0);
       final int loadedReplicantsInTier = params.getSegmentReplicantLookup()
                                                .getLoadedReplicants(segment.getIdentifier(), tier);
 
@@ -73,26 +120,14 @@ public abstract class LoadRule implements Rule
         continue;
       }
 
-      final int maxSegmentsInNodeLoadingQueue = params.getCoordinatorDynamicConfig()
-                                                      .getMaxSegmentsInNodeLoadingQueue();
-
-      Predicate<ServerHolder> serverHolderPredicate;
-      if (maxSegmentsInNodeLoadingQueue > 0) {
-        serverHolderPredicate = s -> (s != null && s.getNumberOfSegmentsInQueue() < maxSegmentsInNodeLoadingQueue);
-      } else {
-        serverHolderPredicate = Objects::nonNull;
-      }
-
       final List<ServerHolder> serverHolderList = serverQueue.stream()
                                                              .filter(serverHolderPredicate)
                                                              .collect(Collectors.toList());
 
-      final BalancerStrategy strategy = params.getBalancerStrategy();
       if (availableSegments.contains(segment)) {
-        int assignedCount = assign(
+        int assignedCount = assignReplicas(
             params.getReplicationManager(),
             tier,
-            totalReplicantsInCluster,
             expectedReplicantsInTier,
             totalReplicantsInTier,
             strategy,
@@ -108,14 +143,57 @@ public abstract class LoadRule implements Rule
     // Remove over-replication
     stats.accumulate(drop(loadStatus, segment, params));
 
-
     return stats;
   }
 
-  private int assign(
+  private static Optional<ServerHolder> getPrimaryHolder(
+      final DruidCluster cluster,
+      final Map<String, Integer> tieredReplicants,
+      final BalancerStrategy strategy,
+      final DataSegment segment,
+      final Predicate<ServerHolder> serverHolderPredicate
+  )
+  {
+    final List<ServerHolder> candidates = Lists.newLinkedList();
+
+    for (final Map.Entry<String, Integer> entry : tieredReplicants.entrySet()) {
+      final int expectedReplicantsInTier = entry.getValue();
+      if (expectedReplicantsInTier <= 0) {
+        continue;
+      }
+
+      final String tier = entry.getKey();
+
+      final MinMaxPriorityQueue<ServerHolder> serverQueue = cluster.getHistoricalsByTier(tier);
+      if (serverQueue == null) {
+        log.makeAlert("Tier[%s] has no servers! Check your cluster configuration!", tier).emit();
+        continue;
+      }
+
+      final ServerHolder candidate = strategy.findNewSegmentHomeReplicator(
+          segment,
+          serverQueue.stream().filter(serverHolderPredicate).collect(Collectors.toList())
+      );
+      if (candidate == null) {
+        log.warn(
+            "Not enough [%s] servers or node capacity to assign primary segment[%s]! Expected Replicants[%d]",
+            tier,
+            segment.getIdentifier(),
+            expectedReplicantsInTier
+        );
+      } else {
+        candidates.add(candidate);
+      }
+    }
+
+    return candidates
+        .stream()
+        .max((s1, s2) -> Ints.compare(s1.getServer().getPriority(), s2.getServer().getPriority()));
+  }
+
+  private int assignReplicas(
       final ReplicationThrottler replicationManager,
       final String tier,
-      final int totalReplicantsInCluster,
       final int expectedReplicantsInTier,
       final int totalReplicantsInTier,
       final BalancerStrategy strategy,
@@ -125,11 +203,8 @@ public abstract class LoadRule implements Rule
   {
     int assignedCount = 0;
     int currReplicantsInTier = totalReplicantsInTier;
-    int currTotalReplicantsInCluster = totalReplicantsInCluster;
     while (currReplicantsInTier < expectedReplicantsInTier) {
-      boolean replicate = currTotalReplicantsInCluster > 0;
-
-      if (replicate && !replicationManager.canCreateReplicant(tier)) {
+      if (!replicationManager.canCreateReplicant(tier)) {
         break;
       }
 
@@ -145,11 +220,11 @@ public abstract class LoadRule implements Rule
         break;
       }
 
-      if (replicate) {
-        replicationManager.registerReplicantCreation(
-            tier, segment.getIdentifier(), holder.getServer().getHost()
-        );
-      }
+      replicationManager.registerReplicantCreation(
+          tier,
+          segment.getIdentifier(),
+          holder.getServer().getHost()
+      );
 
       holder.getPeon().loadSegment(
           segment,
@@ -169,7 +244,6 @@ public abstract class LoadRule implements Rule
 
       ++assignedCount;
       ++currReplicantsInTier;
-      ++currTotalReplicantsInCluster;
     }
 
     return assignedCount;

--- a/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorRuleRunnerTest.java
+++ b/server/src/test/java/io/druid/server/coordinator/DruidCoordinatorRuleRunnerTest.java
@@ -1163,7 +1163,7 @@ public class DruidCoordinatorRuleRunnerTest
                             1000,
                             ServerType.HISTORICAL,
                             "hot",
-                            0
+                            1
                         ).toImmutableDruidServer(),
                         mockPeon
                     )


### PR DESCRIPTION
This PR seeks to address the phenomenon that [loading on a tier (i.e., icy) seems to block another tier (i.e., cold) from loading even when the latter should be opened for loading](https://metamarkets.atlassian.net/browse/BACKEND-935). The main mechanism uses the `priority` parameter set on the server to prioritized which server is selected as the holder of the primary replica. Note that the `priority` parameter, I believe, is intended mainly for query processing, rather than segment loading.

In the current implementation, the primary replica will be assigned to the tier that comes first in the `tieredReplicants` map when there is no replica in the cluster and this replica will not be throttled:
https://github.com/metamx/druid/blob/f5697c806215ac268585d3acc4b2f0048ff2fa83/server/src/main/java/io/druid/server/coordinator/rules/LoadRule.java#L130-L134

The change in this PR simply identifies if the primary replica needs to be loaded (i.e., when `totalReplicantsInCluster <= 0`) and will prioritize appropriately (i.e., select among the candidate servers the one with the highest priority).

I feel that the advantage of this approach, as opposed to using an additional explicit configuration (i.e., on the load order) is that there will not be any modifications required on the existing configuration. But I am *_totally_* okay with redoing the PR if you feel that having an explicit configuration or any other method would be better.

> Note that at the time of submission, it is still unclear, at least to me, why this phenomenon happen because it does seem that it is impossible that any from of "blocking" will happen across tiers. Unfortunately, there is limited data for further investigation. Hence, this PR is really a preventive measure rather than a actual solution.